### PR TITLE
provide default for CondorCEHistoryFolder in code (SOFTWARE-2463)

### DIFF
--- a/common/gratia/common/probe_config.py
+++ b/common/gratia/common/probe_config.py
@@ -349,7 +349,8 @@ class ProbeConfiguration:
         return self.__getConfigAttribute('GratiaExtension')
 
     def get_CondorCEHistoryFolder(self):
-        return self.__getConfigAttribute('CondorCEHistoryFolder')
+        _default = "/var/lib/gratia/condorce_data"
+        return self.__getConfigAttribute('CondorCEHistoryFolder') or _default
 
     def get_CertificateFile(self):
         return self.__getConfigAttribute('CertificateFile')


### PR DESCRIPTION
This went into OSG's gratia-probe 1.17.0-2.3 release.