### PR TITLE
Suppress locally run payload job records (SOFTWARE-2532)

### DIFF
--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -742,6 +742,8 @@ def classadToJUR(classad):
             r.Grid("Campus", "Campus Factory Usage")
         elif campus_flock_usage.search(classad['MATCH_EXP_JOBGLIDEIN_ResourceName']):
             r.Grid("Campus", "Campus Flocking Usage")
+        elif classad['MATCH_EXP_JOBGLIDEIN_ResourceName'] == "Local Job":
+            r.Grid("Local", "Local execution based on ResourceName")
 
     if 'JobUniverse' in classad:
         # scheduler and local universes are always considered to be local


### PR DESCRIPTION
If users set 'SuppressGridLocalRecords=1' in their ProbeConfig and use
the following, recommended HTCondor configuration, Gratia will ignore
jobs that complete on a non-glidein slot:

```
JOBGLIDEIN_ResourceName=\
"$$([IfThenElse(IsUndefined(TARGET.GLIDEIN_ResourceName), \
    IfThenElse(IsUndefined(TARGET.GLIDEIN_Site), \
        \"Local Job\",
        TARGET.GLIDEIN_Site),
    TARGET.GLIDEIN_ResourceName)])"
SUBMIT_EXPRS = $(SUBMIT_EXPRS) JOBGLIDEIN_ResourceName
```