### PR TITLE
Don't use svn:keywords anymore (SOFTWARE-2538)

### DIFF
--- a/boinc/boincprobe.py
+++ b/boinc/boincprobe.py
@@ -26,8 +26,7 @@ localjobid = ''
 endtime = ''
 user = 'Einstein@Home'
 
-rev = '$Revision: 3273 $'
-Gratia.RegisterReporterLibrary('myprobe.py', Gratia.ExtractSvnRevision(rev))
+Gratia.RegisterReporterLibrary('myprobe.py')
 
 for var in flist:
     if var.count('history') > 0:

--- a/common/GratiaPing
+++ b/common/GratiaPing
@@ -1,7 +1,5 @@
 #!/bin/env python
 
-#@(#)gratia/probe/common:$HeadURL$:$Id$
-
 import getopt,sys
 import gratia.common.GratiaCore as GratiaCore
 import gratia.common.bundle as bundle

--- a/common/GratiaPing
+++ b/common/GratiaPing
@@ -36,8 +36,7 @@ if __name__ == '__main__':
                         Usage()
                         sys.exit(0)
 
-        rev = "$Revision$"
-        probe_details.RegisterReporter("GratiaPing.py",utils.ExtractSvnRevision(rev))
+        probe_details.RegisterReporter("GratiaPing.py")
 
         GratiaCore.Initialize()
 

--- a/common/gratia/common/Gratia.py
+++ b/common/gratia/common/Gratia.py
@@ -48,9 +48,6 @@ from gratia.common.GratiaCore import Initialize
 from gratia.common.GratiaCore import Maintenance
 from gratia.common.utils import setProbeBatchManager
 
-from gratia.common.utils import ExtractCvsRevision, ExtractCvsRevisionFromFile, ExtractSvnRevision, ExtractSvnRevisionFromFile
-
-
 # Privates globals
 
 

--- a/common/gratia/common/Gratia.py
+++ b/common/gratia/common/Gratia.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# @(#)gratia/probe/common:$HeadURL$:$Id$
 
 """
 Gratia Job Usage Record Library

--- a/common/gratia/common/GratiaCore.py
+++ b/common/gratia/common/GratiaCore.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# @(#)gratia/probe/common:$HeadURL: https://gratia.svn.sourceforge.net/svnroot/gratia/trunk/probe/common/Gratia.py $:$Id$
 
 """
 Gratia Core Probe Library

--- a/common/gratia/common/GratiaCore.py
+++ b/common/gratia/common/GratiaCore.py
@@ -38,7 +38,7 @@ from gratia.common.probe_details import ProbeDetails, RegisterReporter, Register
 from gratia.common.probe_config import ProbeConfiguration
 from gratia.common.sandbox_mgmt import QuarantineFile, SearchOutstandingRecord
 
-from gratia.common.utils import niceNum, InternalError, ExtractCvsRevision, ExtractCvsRevisionFromFile, ExtractSvnRevision, ExtractSvnRevisionFromFile, TimeToString, setProbeBatchManager
+from gratia.common.utils import niceNum, InternalError, TimeToString, setProbeBatchManager
 from gratia.common.debug import Error, DebugPrint, DebugPrintTraceback
 from gratia.common.xml_utils import XmlChecker, escapeXML
 from gratia.common.send import Send, SendXMLFiles, Handshake

--- a/common/gratia/common/probe_details.py
+++ b/common/gratia/common/probe_details.py
@@ -10,13 +10,13 @@ from gratia.common.debug import DebugPrint
 
 __handshakeReg__ = []
 
-def RegisterReporterLibrary(name, version):
+def RegisterReporterLibrary(name, version="%%%RPMVERSION%%%"):
     """Register the library named 'name' with version 'version'"""
 
     __handshakeReg__.append(('ReporterLibrary', 'version="' + version[0:254] + '"', name))
 
 
-def RegisterReporter(name, version):
+def RegisterReporter(name, version="%%%RPMVERSION%%%"):
     """Register the software named 'name' with version 'version'"""
 
     __handshakeReg__.append(('Reporter', 'version="' + version[0:254]+ '"', name))
@@ -39,20 +39,16 @@ class ProbeDetails(record.Record):
 
         self.__ProbeDetails__ = []
 
-        # Extract the revision number
-
-        rev = utils.ExtractSvnRevision('$Revision: 3997 $')
-
-        self.ReporterLibrary('Gratia', rev)
+        self.ReporterLibrary('Gratia')
 
         for data in __handshakeReg__:
             self.__ProbeDetails__ = self.AppendToList(self.__ProbeDetails__, data[0], data[1], data[2])
 
-    def ReporterLibrary(self, name, version):
+    def ReporterLibrary(self, name, version="%%%RPMVERSION%%%"):
         self.__ProbeDetails__ = self.AppendToList(self.__ProbeDetails__, 'ReporterLibrary', 'version="' + version[0:254] + '"'
                                               , name)
 
-    def Reporter(self, name, version):
+    def Reporter(self, name, version="%%%RPMVERSION%%%"):
         self.__ProbeDetails__ = self.AppendToList(self.__ProbeDetails__, 'Reporter', 'version="' + version[0:254] + '"', name)
 
     def Service(self, name, version):

--- a/common/gratia/common/utils.py
+++ b/common/gratia/common/utils.py
@@ -116,39 +116,12 @@ class InternalError(exceptions.Exception):
     pass
 
 
-def ExtractCvsRevision(revision):
-
-    # Extra the numerical information from the CVS keyword:
-    # $Revision\: $
-
-    return revision.split('$')[1].split(':')[1].strip()
-
-    
-def ExtractCvsRevisionFromFile(filename):
-    pipe = os.popen(r"sed -ne 's/.*\$Revision\: \([^$][^$]*\)\$.*$/\1/p' " + filename)
-    result = None
-    if pipe != None:
-        result = string.strip(pipe.readline())
-        pipe.close()
-    return result
-
-
 def ExtractSvnRevision(revision):
 
     # Extra the numerical information from the SVN keyword:
     # $Revision\: $
 
     return revision.split('$')[1].split(':')[1].strip()
-
-
-def ExtractSvnRevisionFromFile(filename):
-    pipe = os.popen(r"sed -ne 's/.*\$Revision\: \([^$][^$]*\)\$.*$/\1/p' " + filename)
-    result = None
-    if pipe != None:
-        result = string.strip(pipe.readline())
-        pipe.close()
-    return result
-
 
 def TimeToString(targ=None):
     ''' Return the XML version of the given time.  Default to the current time '''

--- a/common/samplemeter.py
+++ b/common/samplemeter.py
@@ -62,9 +62,7 @@ def GetRecord(jobid=0):
 
 
 if __name__ == '__main__':
-    rev = '$Revision$'
-    probe_details.RegisterReporterLibrary('samplemeterecord.py', 
-                                          utils.ExtractSvnRevision(rev))
+    probe_details.RegisterReporterLibrary('samplemeterecord.py')
 
     GratiaCore.Initialize()
 

--- a/common/samplemeter_multi.py
+++ b/common/samplemeter_multi.py
@@ -58,8 +58,7 @@ def GetRecord(jobid = 0):
         return r
 
 if __name__ == '__main__': 
-        rev = "$Revision$"
-        probe_details.RegisterReporterLibrary("samplemeter.py",utils.ExtractSvnRevision(rev))
+        probe_details.RegisterReporterLibrary("samplemeter.py")
         
         GratiaCore.Initialize()
 

--- a/common2/gratia/common2/alarm.py
+++ b/common2/gratia/common2/alarm.py
@@ -1,7 +1,6 @@
 # Copyright 2007 Cornell University, Ithaca, NY. All rights reserved.
 #
 # Author:  Gregory J. Sharp
-# Version: $Id: Alarm.py,v 1.2 2008/03/17 17:16:49 greenc Exp $
 #
 # This program accepts alarms about error conditions. If the error has
 # occured too frequently in the recent past, it will send a warning email

--- a/common2/gratia/common2/filepinput.py
+++ b/common2/gratia/common2/filepinput.py
@@ -20,7 +20,6 @@ import gratia.common2.checkpoint as checkpoint
 # package inputs are ahead
 
 prog_version = "%%%RPMVERSION%%%"
-prog_revision = '$Revision: 5268 $'
 
 
 # --- functions -----------------------------------------------------------------------

--- a/common2/gratia/common2/meter.py
+++ b/common2/gratia/common2/meter.py
@@ -38,7 +38,6 @@ import timeutil
 from probeinput import ProbeInput
 
 prog_version = "%%%RPMVERSION%%%"
-prog_revision = '$Revision$'
 
 
 # This should be added as improvement of Gratia logging in gratia.common.debug
@@ -435,7 +434,7 @@ class GratiaProbe(object):
 
         :return:
         """
-        Gratia.RegisterReporter(self.probe_name, "%s (tag %s)" % (prog_revision, prog_version))
+        Gratia.RegisterReporter(self.probe_name)
 
         try:
             input_version = self.get_version()

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -32,7 +32,6 @@ g_alternate_records = {}
 g_probe_config = None
 
 prog_version = "%%%RPMVERSION%%%"
-prog_revision = '$Revision$'
 max_batch_size = 500
 
 min_start_time = time.time() - 120*86400
@@ -329,8 +328,7 @@ def parse_date(date_string):
     return result
 
 def register_gratia():
-    GratiaCore.RegisterReporter("condor_meter", "%s (tag %s)" % \
-        (prog_revision, prog_version))
+    GratiaCore.RegisterReporter("condor_meter")
     try:
         condor_version = getCondorVersion()
     except SystemExit:

--- a/dCache-storage/dCache-storage_meter.cron.sh
+++ b/dCache-storage/dCache-storage_meter.cron.sh
@@ -3,8 +3,6 @@
 # dcache-storage_meter.cron.sh - Shell script used with cron to parse dcache-storage
 #   files for OSG accounting data collection.
 #      By Chris Green <greenc@fnal.gov>  Began 5 Sept 2006
-# $Id: dCache-storage_meter.cron.sh,v 1.4 2008/09/08 21:35:34 greenc Exp $
-# Full Path: $Source: /cvs/cd/dcache/gratia/dCache-storage/dCache-storage_meter.cron.sh,v $
 ###################################################################
 PGM=$(basename $0)
 Logger="/usr/bin/logger -s -t $PGM"

--- a/dCache-transfer/README
+++ b/dCache-transfer/README
@@ -1,5 +1,4 @@
 # Copyright 2007 Cornell University, Ithaca, NY. All rights reserved.
-# Version: $Id: README,v 1.7 2008/11/18 21:04:33 tlevshin Exp $
 
 This README describes the dCache transfer probe for Gratia.
 

--- a/dCache-transfer/README-experts-only.txt
+++ b/dCache-transfer/README-experts-only.txt
@@ -1,5 +1,4 @@
 # Copyright 2007 Cornell University, Ithaca, NY. All rights reserved.
-# Version: $Id: README-experts-only.txt,v 1.1 2008/03/17 17:15:46 greenc Exp $
 
 From Gregory Sharp. Modified by Ted Hesselroth and Chris Green.
 

--- a/dCache-transfer/gratia/dcache_transfer/Alarm.py
+++ b/dCache-transfer/gratia/dcache_transfer/Alarm.py
@@ -1,7 +1,6 @@
 # Copyright 2007 Cornell University, Ithaca, NY. All rights reserved.
 #
 # Author:  Gregory J. Sharp
-# Version: $Id: Alarm.py,v 1.2 2008/03/17 17:16:49 greenc Exp $
 #
 # This program accepts alarms about error conditions. If the error has
 # occured too frequently in the recent past, it will send a warning email

--- a/dCache-transfer/gratia/dcache_transfer/Checkpoint.py
+++ b/dCache-transfer/gratia/dcache_transfer/Checkpoint.py
@@ -1,7 +1,6 @@
 # Copyright 2007 Cornell University, Ithaca, NY. All rights reserved.
 #
 # Author:  Gregory J. Sharp
-# Version: $Id: Checkpoint.py,v 1.2 2008/03/17 17:16:49 greenc Exp $
 #
 # This stores a checkpoint to a file to remember which record was last sent
 # to the Gratia repository. This allows us to begin searching from this

--- a/dCache-transfer/gratia/dcache_transfer/CheckpointTest.py
+++ b/dCache-transfer/gratia/dcache_transfer/CheckpointTest.py
@@ -1,7 +1,6 @@
 # Copyright 2007 Cornell University, Ithaca, NY. All rights reserved.
 #
 # Author:  Gregory J. Sharp
-# Version: $Id: CheckpointTest.py,v 1.2 2008/03/17 17:16:49 greenc Exp $
 #
 # This program performs some basic unit tests on the Checkpoint module.
 

--- a/dCache-transfer/gratia/dcache_transfer/DCacheAggregator.py
+++ b/dCache-transfer/gratia/dcache_transfer/DCacheAggregator.py
@@ -1,7 +1,6 @@
 # Copyright 2007 Cornell University, Ithaca, NY. All rights reserved.
 #
 # Author:  Gregory J. Sharp
-# Version: $Id: DCacheAggregator.py,v 1.29 2009/10/21 20:24:46 greenc Exp $
 #
 # This is a first attempt at a python program that reads the dCache billing
 # database, aggregates any new content, and posts it to Gratia.

--- a/dCache-transfer/gratia/dcache_transfer/dCacheBillingAggregator.py
+++ b/dCache-transfer/gratia/dcache_transfer/dCacheBillingAggregator.py
@@ -1,7 +1,6 @@
 # Copyright 2007 Cornell University, Ithaca, NY. All rights reserved.
 #
 # Author:  Gregory J. Sharp
-# Version: $Id: dCacheBillingAggregator.py,v 1.13 2009/09/03 15:52:06 greenc Exp $
 #
 # This is a Python program that reads the dCache billing database, aggregates
 # any new content, and sends it to Gratia.

--- a/dCache-transfer/gratia/dcache_transfer/dCacheBillingAggregator.py
+++ b/dCache-transfer/gratia/dcache_transfer/dCacheBillingAggregator.py
@@ -171,10 +171,7 @@ def main():
         #        using the pkg_resource package?
         Gratia.RegisterReporterLibrary( "psycopg2", "2.0.6" )
         #Gratia.RegisterReporterLibrary( "SQLAlchemy", "0.4.1" )
-        rev =  Gratia.ExtractCvsRevision("$Revision: 1.13 $")
-        tag =  Gratia.ExtractCvsRevision("$Name:  $")
-        Gratia.RegisterReporter( "dCacheBillingAggregator.py",
-                                 str(rev) + " (tag " + str(tag) + ")")
+        Gratia.RegisterReporter( "dCacheBillingAggregator.py" )
 
         # BRIAN: attempt to pull the dCache version from RPM.
         version = "UNKNOWN"

--- a/glexec/glexec_meter
+++ b/glexec/glexec_meter
@@ -176,8 +176,7 @@ def main():
     # Make sure we have an exclusive lock for this probe.
     GratiaWrapper.ExclusiveLock()
 
-    rev =  Gratia.ExtractSvnRevision("$Revision$")
-    Gratia.RegisterReporter("glexec_meter.py", str(rev) + " (tag %%%RPMVERSION%%%)")
+    Gratia.RegisterReporter("glexec_meter.py")
     GratiaCore.Initialize(opts.gratia_config)
 
     cename=getCE(Gratia.Config.get_CertificateFile())

--- a/glexec/glexec_meter.cron.sh
+++ b/glexec/glexec_meter.cron.sh
@@ -3,8 +3,6 @@
 # glexec_meter.cron.sh - Shell script used with cron to parse glexec
 #   files for OSG accounting data collection.
 #      By Chris Green <greenc@fnal.gov>  Began 5 Sept 2006
-# $Id$
-# Full Path: $HeadURL$
 ###################################################################
 PGM=$(basename $0)
 Logger="/usr/bin/logger -s -t $PGM"

--- a/metric/gratia/metric/Metric.py
+++ b/metric/gratia/metric/Metric.py
@@ -1,4 +1,3 @@
-#@(#)gratia/probe/metric:$HeadURL$:$Id$
 
 ## Updated by Arvind Gopu, Indiana University (http://peart.ucs.indiana.edu)
 ## More Updates by Arvind Gopu 2007-10-19

--- a/pbs-lsf/pbs-lsf
+++ b/pbs-lsf/pbs-lsf
@@ -5,9 +5,8 @@ import sys
 import gratia.common.Gratia as Gratia
 
 if __name__ == '__main__':
-        rev = Gratia.ExtractSvnRevision("$Revision$");
         tag = "%%%RPMVERSION%%%";
-        Gratia.RegisterReporter("pbs-lsf.py", str(rev) + " (tag " + str(tag) + ")")
+        Gratia.RegisterReporter("pbs-lsf.py")
 	if hasattr(sys,'argv') and sys.argv[1]:
                 if (len(sys.argv) >= 3 and sys.argv[2]):
                         Gratia.setProbeBatchManager(sys.argv[2])

--- a/pbs-lsf/pbs-lsf_meter.cron.sh
+++ b/pbs-lsf/pbs-lsf_meter.cron.sh
@@ -3,8 +3,6 @@
 # pbs-lsfr_meter.cron.sh - Shell script used with cron to parse PBS and LSF
 #   files for OSG accounting data collection.
 #      By Chris Green <greenc@fnal.gov>  Began 5 Sept 2006
-# $Id$
-# Full Path: $HeadURL$
 ###################################################################
 function check_if_running {
   # Need to be sure there is not one of these running already

--- a/services/gratia/services/ComputeElement.py
+++ b/services/gratia/services/ComputeElement.py
@@ -1,4 +1,3 @@
-#@(#)gratia/probe/glue:$HeadURL: https://gratia.svn.sourceforge.net/svnroot/gratia/trunk/probe/glue/ComputeElement.py $:$Id: ComputeElement.py 3000 2009-02-16 16:15:08Z pcanal $
 
 ## Updated by Brian Bockelman, University of Nebraska-Lincoln (http://rcf.unl.edu)
 

--- a/services/gratia/services/ComputeElementRecord.py
+++ b/services/gratia/services/ComputeElementRecord.py
@@ -1,4 +1,3 @@
-#@(#)gratia/probe/glue:$HeadURL: https://gratia.svn.sourceforge.net/svnroot/gratia/trunk/probe/glue/ComputeElementRecord.py $:$Id: ComputeElementRecord.py 3000 2009-02-16 16:15:08Z pcanal $
 
 ## Updated by Brian Bockelman, University of Nebraska-Lincoln (http://rcf.unl.edu)
 

--- a/services/gratia/services/StorageElement.py
+++ b/services/gratia/services/StorageElement.py
@@ -1,4 +1,3 @@
-#@(#)gratia/probe/glue:$HeadURL: https://gratia.svn.sourceforge.net/svnroot/gratia/trunk/probe/glue/StorageElement.py $:$Id: StorageElement.py 3000 2009-02-16 16:15:08Z pcanal $
 
 ## Updated by Brian Bockelman, University of Nebraska-Lincoln (http://rcf.unl.edu)
 

--- a/services/gratia/services/StorageElementRecord.py
+++ b/services/gratia/services/StorageElementRecord.py
@@ -1,4 +1,3 @@
-#@(#)gratia/probe/glue:$HeadURL: https://gratia.svn.sourceforge.net/svnroot/gratia/trunk/probe/glue/StorageElementRecord.py $:$Id: StorageElementRecord.py 3000 2009-02-16 16:15:08Z pcanal $
 
 ## Updated by Brian Bockelman, University of Nebraska-Lincoln (http://rcf.unl.edu)
 

--- a/services/gratia/services/Subcluster.py
+++ b/services/gratia/services/Subcluster.py
@@ -1,4 +1,3 @@
-#@(#)gratia/probe/glue:$HeadURL: https://gratia.svn.sourceforge.net/svnroot/gratia/trunk/probe/glue/Subcluster.py $:$Id: Subcluster.py 3000 2009-02-16 16:15:08Z pcanal $
 
 ## Updated by Brian Bockelman, University of Nebraska-Lincoln (http://rcf.unl.edu)
 

--- a/sge/sge_meter.cron.sh
+++ b/sge/sge_meter.cron.sh
@@ -3,9 +3,6 @@
 # sge_meter.cron.sh - Shell script used with cron to parse sge log 
 #   files for OSG accounting data collection.
 
-# $Id$
-# Full Path: $HeadURL$
-
 Logger='/usr/bin/logger -s -t sge_meter'
 
 # NOTE: some of the comments in this script indicate work still to be done.

--- a/slurm/SlurmProbe.py
+++ b/slurm/SlurmProbe.py
@@ -26,7 +26,6 @@ import re
 from distutils.version import LooseVersion
 
 prog_version = "%%%RPMVERSION%%%"
-prog_revision = '$Revision$'
 
 class SlurmProbe:
 
@@ -150,8 +149,7 @@ class SlurmProbe:
         return version
 
     def register_gratia(self, name):
-        Gratia.RegisterReporter(name, "%s (tag %s)" % \
-            (prog_revision, prog_version))
+        Gratia.RegisterReporter(name)
 
         try:
             slurm_version = self.get_slurm_version()

--- a/test/gratia-site-diag
+++ b/test/gratia-site-diag
@@ -49,7 +49,7 @@ if (not scalar @ARGV) {
   $options{local} = 1;
 }
 
-print "gratia-site-diag version ", '$Revision$', "\n";
+print "gratia-site-diag version ", "%%%RPMVERSION%%%", "\n";
 
 foreach my $gk (@ARGV) {
   print "SITE: $gk\n";


### PR DESCRIPTION
This removes remaining uses of `$Revision$` and `$Id$`-style svn:keywords that were being used in the svn version of gratia.

The only relevant bit is that the version of the probes does in fact get sent to the gratia collector.  Rather than try to reproduce the old behavior by filling these keyword fields in with revision information at build time, we will send the rpm VR string, which is actually more precise even than a git hash, since an rpm build may contain patches on top of the upstream sources.

I talked with @bbockelm and @djw8605 about this last week, who seemed to be happy with this plan.  But please comment if you think there are any issues.