### PR TITLE
SUBMIT_EXPRS has been deprecated in favor of SUBMIT_ATTRS

### DIFF
--- a/condor/99_gratia-gwms.conf
+++ b/condor/99_gratia-gwms.conf
@@ -19,5 +19,5 @@ JOBGLIDEIN_ResourceName="$$([IfThenElse(IsUndefined(TARGET.GLIDEIN_ResourceName)
 
 # Add the JOBGLIDEIN_ResourceName to every job that is submitted from
 # this host
-SUBMIT_EXPRS = $(SUBMIT_EXPRS) JOBGLIDEIN_ResourceName   
+SUBMIT_ATTRS = $(SUBMIT_ATTRS) JOBGLIDEIN_ResourceName
 


### PR DESCRIPTION
Dan Bradley helpfully pointed this out in [GOC #31438](https://ticket.opensciencegrid.org/31438)