### PR TITLE
Use MATCH_EXP_JOB_GLIDEIN_Cpus for whole node jobs

### DIFF
--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -726,6 +726,8 @@ def classadToJUR(classad):
     ########################################################################################
     if 'MachineAttrCpus0' in classad:
         r.Processors(classad['MachineAttrCpus0'], metric="max")
+    elif 'MATCH_EXP_JOB_GLIDEIN_Cpus' in classad:
+        r.Processors(int(classad['MATCH_EXP_JOB_GLIDEIN_Cpus']), metric="max")
     elif 'RequestCpus' in classad:
         r.Processors(classad['RequestCpus'], metric="max")
     else:


### PR DESCRIPTION
The HTCondor-CE adds a new attribute MATCH_EXP_JOB_GLIDEIN_Cpus
which is set to the number of cpus allocated in the last
match.

HTCondor-CE sets `MATCH_EXP_JOB_GLIDEIN_Cpus` in https://github.com/opensciencegrid/htcondor-ce/pull/151