### PR TITLE
Classad attr are case insensitive (SOFTWARE-3017)

### DIFF
--- a/build/gratia-probe.spec
+++ b/build/gratia-probe.spec
@@ -1,7 +1,7 @@
 Name:               gratia-probe
 Summary:            Gratia OSG accounting system probes
 Group:              Applications/System
-Version:            1.19.0
+Version:            1.19.1
 Release:            1%{?dist}
 
 License:            GPL
@@ -497,6 +497,7 @@ Summary: A Condor probe
 Group: Applications/System
 Requires: %{name}-common >= %{version}-%{release}
 Requires: condor
+Requires: condor-python
 
 %description condor
 The Condor probe for the Gratia OSG accounting system.
@@ -999,6 +1000,9 @@ The dCache storagegroup probe for the Gratia OSG accounting system.
 %endif # noarch
 
 %changelog
+* Wed Jan 24 2018 Carl Edquist <edquist@cs.wisc.edu> - 1.19.1-1
+- Always use classad lib in condor probe (SOFTWARE-3017)
+
 * Thu Dec 21 2017 Carl Edquist <edquist@cs.wisc.edu> - 1.19.0-1
 - Add GPU support to common probe code (SOFTWARE-3084)
 

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -23,11 +23,8 @@ import gratia.common.Gratia as Gratia
 import gratia.common.file_utils as file_utils
 import gratia.common.config as config
 
-g_has_classad = True
-try:
-    import classad as classadLib
-except ImportError:
-    g_has_classad = False
+import classad as classadLib
+
 g_alternate_records = {}
 g_probe_config = None
 
@@ -41,83 +38,6 @@ min_start_time = time.time() - 120*86400
 
 class IgnoreClassadException(Exception):
     pass
-
-
-# ********************************************
-# class     caselessDict
-#           http://code.activestate.com/recipes/66315-case-insensitive-dictionary/
-# purpose   emulate a normal Python dictionary
-#           but with keys which can accept the
-#           lower() method (typically strings).
-#           Accesses to the dictionary are
-#           case-insensitive but keys returned
-#           from the dictionary are always in
-#           the original case.
-# ********************************************
-
-class caselessDict:
-    def __init__(self, inDict=None):
-        """Constructor: takes conventional dictionary
-           as input (or nothing)"""
-        self.dict = {}
-        if inDict != None:
-            for key in inDict:
-                k = key.lower()
-                self.dict[k] = (key, inDict[key])
-        self.keyList = self.dict.keys()
-        self.iterPosition = 0
-        return
-
-    def __iter__(self):
-        self.iterPosition = 0
-        return self
-
-    def next(self):
-        if self.iterPosition >= len(self.keyList):
-            raise StopIteration
-        x = self.dict[self.keyList[self.iterPosition]][0]
-        self.iterPosition += 1
-        return x
-
-    def __getitem__(self, key):
-        k = key.lower()
-        return self.dict[k][1]
-
-    def __setitem__(self, key, value):
-        k = key.lower()
-        self.dict[k] = (key, value)
-        self.keyList = self.dict.keys()
-
-    def has_key(self, key):
-        k = key.lower()
-        return k in self.keyList
-
-    def __len__(self):
-        return len(self.dict)
-
-    def get(self, key, alt):
-        if self.has_key(key):
-            return self.__getitem__(key)
-        return alt
-
-    def keys(self):
-        return [v[0] for v in self.dict.values()]
-
-    def values(self):
-        return [v[1] for v in self.dict.values()]
-
-    def items(self):
-        return self.dict.values()
-
-    def __contains__(self, item):
-        return self.dict.has_key(item.lower())
-
-    def __repr__(self):
-        items = ", ".join([("%r: %r" % (k, v)) for k, v in self.items()])
-        return "{%s}" % items
-
-    def __str__(self):
-        return repr(self)
 
 
 # --- functions -----------------------------------------------------------------------
@@ -811,63 +731,22 @@ classad_double_re = re.compile("^(\w{1,255}) = ([+-]? *(?:\d{1,30}\.?\d{0,30}|\.
 classad_string_re = re.compile("^(\S+) = \"(.*)\"$")
 classad_catchall_re = re.compile("^(\S+) = (.*)$")
 def fd_to_classad(fd):
-    if g_has_classad:
-        buffer = ''
-    else:
-        classad = caselessDict()
+    buffer = ''
     for lineOrig in fd.readlines():
         line = lineOrig.strip()
-        if g_has_classad:
-           if not line:
-               if hasattr(classadLib, 'parseOne'):
-                   yield add_unique_id(classadLib.parseOne(buffer))
-               else:
-                   yield add_unique_id(classadLib.parseOld(buffer))
-               buffer = ''
-           else:
-               buffer += lineOrig
-           continue
-        m = classad_bool_re.match(line)
-        if m:
-            attr, val = m.groups()
-            if val.lower().find("true") >= 0:
-                classad[attr] = True
-            else:
-                classad[attr] = False
-            continue
-        m = classad_int_re.match(line)
-        if m:
-            attr, val = m.groups()
-            classad[attr] = int(val)
-            continue
-        m = classad_double_re.match(line)
-        if m:
-            attr, val = m.groups()
-            classad[attr] = float(val)
-            continue
-        m = classad_string_re.match(line)
-        if m:
-            attr, val = m.groups()
-            classad[attr] = str(val)
-            continue
-        m = classad_catchall_re.match(line)
-        if m:
-            attr, val = m.groups()
-            classad[attr] = str(val)
-            continue
         if not line:
-            yield add_unique_id(classad)
-            classad = caselessDict()
-            continue
-        DebugPrint(2, "Invalid line in ClassAd: %s" % line)
-
-    if g_has_classad:
-        if hasattr(classadLib, 'parseOne'):
-            yield add_unique_id(classadLib.parseOne(buffer))
+            if hasattr(classadLib, 'parseOne'):
+                yield add_unique_id(classadLib.parseOne(buffer))
+            else:
+                yield add_unique_id(classadLib.parseOld(buffer))
+            buffer = ''
         else:
-            yield add_unique_id(classadLib.parseOld(buffer))
+            buffer += lineOrig
+
+    if hasattr(classadLib, 'parseOne'):
+        yield add_unique_id(classadLib.parseOne(buffer))
     else:
-        yield add_unique_id(classad)
+        yield add_unique_id(classadLib.parseOld(buffer))
         
 def add_unique_id(classad):
     if 'GlobalJobId' in classad:

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -737,7 +737,7 @@ classad_string_re = re.compile("^(\S+) = \"(.*)\"$")
 classad_catchall_re = re.compile("^(\S+) = (.*)$")
 def fd_to_classad(fd):
     buffer = ''
-    for lineOrig in fd.readlines():
+    for lineOrig in fd:
         line = lineOrig.strip()
         if not line:
             yield add_unique_id(classadLib.parseOne(buffer))

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -740,19 +740,13 @@ def fd_to_classad(fd):
     for lineOrig in fd.readlines():
         line = lineOrig.strip()
         if not line:
-            if hasattr(classadLib, 'parseOne'):
-                yield add_unique_id(classadLib.parseOne(buffer))
-            else:
-                yield add_unique_id(classadLib.parseOld(buffer))
+            yield add_unique_id(classadLib.parseOne(buffer))
             buffer = ''
         else:
             buffer += lineOrig
 
-    if hasattr(classadLib, 'parseOne'):
-        yield add_unique_id(classadLib.parseOne(buffer))
-    else:
-        yield add_unique_id(classadLib.parseOld(buffer))
-        
+    yield add_unique_id(classadLib.parseOne(buffer))
+
 def add_unique_id(classad):
     if 'GlobalJobId' in classad:
         classad['UniqGlobalJobId'] = 'condor.%s' % classad['GlobalJobId']

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -25,6 +25,11 @@ import gratia.common.config as config
 
 import classad as classadLib
 
+# HACK: allow case-insensitive `attr in ad` checks
+# https://jira.opensciencegrid.org/browse/SOFTWARE-3017
+# https://github.com/opensciencegrid/gratia-probe/pull/24
+classadLib.ClassAd.__contains__ = lambda ad,attr: ad.get(attr) is not None
+
 g_alternate_records = {}
 g_probe_config = None
 


### PR DESCRIPTION
Accessing classad attr via 'classad.get(attr)' or 'classad[attr]' allows
for case insensitive access but 'attr in classad' does not. This
caused us to miss picking up attributes in the ad