### PR TITLE
handle walltime and cput in raw seconds in pbs probe (SOFTWARE-3221)

### DIFF
--- a/pbs-lsf/urCollector-src/urCollector.pl
+++ b/pbs-lsf/urCollector-src/urCollector.pl
@@ -1332,9 +1332,15 @@ sub parseUR_pbs {
       if ( $record_field =~ /^resources_used\.cput=.*?(\d+):(\d+):(\d+)$/o) {
          $urAcctlogInfo{cput}= $3 + $2*60 + $1*3600;
          next;
+      } elsif ( $record_field =~ /^resources_used\.cput=.*?(\d+)$/o) {
+         $urAcctlogInfo{cput}= $1;
+         next;
       }
       if ( $record_field =~ /^resources_used\.walltime=*?(\d+):(\d+):(\d+)$/o) {
          $urAcctlogInfo{walltime}= $3 + $2*60 + $1*3600;
+         next;
+      } elsif ( $record_field =~ /^resources_used\.walltime=*?(\d+)$/o) {
+         $urAcctlogInfo{walltime}= $1;
          next;
       }
       if ( $record_field =~ /^resources_used\.vmem=.*?(\d*[M.k]b)$/o) {


### PR DESCRIPTION
Apparently the value for resources_used.{walltime,cput} can appear
either as HH:MM:SS or as raw seconds.

This came up in https://ticket.opensciencegrid.org/35824