### PR TITLE
drop obsolete twiki links (SOFTWARE-3211)

### DIFF
--- a/boinc/README
+++ b/boinc/README
@@ -1,12 +1,4 @@
-For up-to-date documentation including installation and configuration instructions, please see:
+For help with installation and configuration, please contact:
 
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeInstallation
+    help@opensciencegrid.org
 
-If you are installing a specific probe, please see the configuration
-instructions for that probe; if you are writing your own probe, please
-see the general notes at:
-
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeConfigGeneral
-
-------------------------------------------------------------------------
-2006/12/22 Chris Green

--- a/common/README
+++ b/common/README
@@ -1,12 +1,4 @@
-For up-to-date documentation including installation and configuration instructions, please see:
+For help with installation and configuration, please contact:
 
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeInstallation
+    help@opensciencegrid.org
 
-If you are installing a specific probe, please see the configuration
-instructions for that probe; if you are writing your own probe, please
-see the general notes at:
-
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeConfigGeneral
-
-------------------------------------------------------------------------
-2006/12/22 Chris Green

--- a/condor/README
+++ b/condor/README
@@ -1,10 +1,4 @@
-For up-to-date documentation including installation and configuration instructions, please see:
+For help with installation and configuration, please contact:
 
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeInstallation
+    help@opensciencegrid.org
 
-and
-
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeConfigCondor
-
-------------------------------------------------------------------------
-2006/12/22 Chris Green

--- a/metric/README
+++ b/metric/README
@@ -1,11 +1,4 @@
-For up-to-date documentation including installation and configuration
-instructions, please see:
+For help with installation and configuration, please contact:
 
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeInstallation
+    help@opensciencegrid.org
 
-and
-
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeConfigMetric
-
-------------------------------------------------------------------------
-2007/07/03 Chris Green

--- a/pbs-lsf/README
+++ b/pbs-lsf/README
@@ -1,10 +1,4 @@
-For up-to-date documentation including installation and configuration instructions, please see:
+For help with installation and configuration, please contact:
 
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeInstallation
+    help@opensciencegrid.org
 
-and
-
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeConfigPbsLsf
-
-------------------------------------------------------------------------
-2006/12/22 Chris Green

--- a/sge/README
+++ b/sge/README
@@ -1,11 +1,4 @@
-For up-to-date documentation including installation and configuration
-instructions, please see:
+For help with installation and configuration, please contact:
 
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeInstallation
+    help@opensciencegrid.org
 
-and
-
-https://twiki.grid.iu.edu/bin/view/Accounting/ProbeConfigSge
-
-------------------------------------------------------------------------
-2006/02/02 Chris Green


### PR DESCRIPTION
Unfortunately, the Accounting web of the twiki was never migrated, so there is no replacement documentation to point users to.