### PR TITLE
log unhandled exceptions in slurm probe (SOFTWARE-2456)

### DIFF
--- a/build/gratia-probe.spec
+++ b/build/gratia-probe.spec
@@ -1,7 +1,7 @@
 Name:               gratia-probe
 Summary:            Gratia OSG accounting system probes
 Group:              Applications/System
-Version:            1.20.4
+Version:            1.20.5
 Release:            1%{?dist}
 
 License:            GPL
@@ -959,6 +959,9 @@ The dCache storagegroup probe for the Gratia OSG accounting system.
 %endif # noarch
 
 %changelog
+* Wed Aug 22 2018 Carl Edquist <edquist@cs.wisc.edu> - 1.20.5-1
+- Log unhandled exceptions in slurm probe (SOFTWARE-2456)
+
 * Tue Jul 24 2018 Carl Edquist <edquist@cs.wisc.edu> - 1.20.4-1
 - Avoid missing records due to lag in slurm probe (SOFTWARE-3347)
 

--- a/slurm/slurm_meter
+++ b/slurm/slurm_meter
@@ -235,4 +235,8 @@ class SlurmMeter(SlurmProbe):
             self.checkpoint.val = time_end + 1
 
 if __name__ == "__main__":
-    SlurmMeter().main()
+    try:
+        SlurmMeter().main()
+    except Exception as e:
+        DebugPrint(1, "Unhandled Exception: %s" % e)
+        raise e

--- a/slurm/slurm_meter
+++ b/slurm/slurm_meter
@@ -238,5 +238,5 @@ if __name__ == "__main__":
     try:
         SlurmMeter().main()
     except Exception as e:
-        DebugPrint(1, "Unhandled Exception: %s" % e)
-        raise e
+        DebugPrint(1, "ERROR: Unhandled Exception: %s" % e)
+        raise


### PR DESCRIPTION
the traceback still goes to stderr, but never got logged to the gratia
logs.  by using DebugPrint, at least the error will make it to the
gratia logs.