### PR TITLE
Processors field: Evaluate ClassAd expr and ensure a default of 1 (SOFTWARE-3474, SOFTWARE-3476)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - "2.7"
+env:
+  matrix:
+  - CONDOR_SERIES=8.8  # stable
+  - CONDOR_SERIES=8.7  # development
+install:
+  - pip install pyopenssl htcondor~=$CONDOR_SERIES
+  - make install_python
+  - cp condor/condor_meter{,.py}  # for importing condor_meter
+script:
+  - test/run_unit_tests.sh
+
+notifications:
+  email: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,3 @@ install:
 script:
   - test/run_unit_tests.sh
 
-notifications:
-  email: false
-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+PYTHON_ROOT_FILES := common/gratia/__init__.py
+PYTHON_COMMON_FILES := common/gratia/common/*.py
+PYTHON_COMMON2_FILES :=  common2/gratia/common2/*.py
+
+INSTALL_PYTHON_DIR := $(shell python -c 'from distutils.sysconfig import get_python_lib; print get_python_lib()')
+
+_default: install_python
+
+install_python:
+	mkdir -p $(DESTDIR)/$(INSTALL_PYTHON_DIR)/gratia/common
+	mkdir $(DESTDIR)/$(INSTALL_PYTHON_DIR)/gratia/common2
+	install -p -m 0644 $(PYTHON_ROOT_FILES) $(DESTDIR)/$(INSTALL_PYTHON_DIR)/gratia/
+	install -p -m 0644 $(PYTHON_COMMON_FILES) $(DESTDIR)/$(INSTALL_PYTHON_DIR)/gratia/common/
+	install -p -m 0644 $(PYTHON_COMMON_FILES) $(DESTDIR)/$(INSTALL_PYTHON_DIR)/gratia/common2/

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -39,6 +39,9 @@ max_batch_size = 500
 
 min_start_time = time.time() - 120*86400
 
+# The preferred order of JobAd attributes to use for determining the number of
+# processors available to the pilot or payload job
+PROC_ATTRS = ['MachineAttrCpus0', 'MATCH_EXP_JOB_GLIDEIN_Cpus', 'RequestCpus']
 
 # --- classes -------------------------------------------------------------------------
 
@@ -160,9 +163,10 @@ def get_num_procs(job_ad):
     If none of the above are set or do not evaluate to an integer, return 0
     """
     procs = 0
-    for attr in ['RequestCpus', 'MATCH_EXP_JOB_GLIDEIN_Cpus', 'MachineAttrCpus0']:
+    for attr in PROC_ATTRS:
         try:
             procs = int(job_ad.eval(attr))
+            break
         except (KeyError, ValueError):
             continue
 

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -157,17 +157,14 @@ def get_num_procs(job_ad):
     2. MATCH_EXP_JOB_GLIDEIN_Cpus
     3. RequestCpus
 
-    If none of the above are set or do not evaluate to an integer, return 1
+    If none of the above are set or do not evaluate to an integer, return 0
     """
-    procs = ''
+    procs = 0
     for attr in ['RequestCpus', 'MATCH_EXP_JOB_GLIDEIN_Cpus', 'MachineAttrCpus0']:
         try:
             procs = int(job_ad.eval(attr))
         except (KeyError, ValueError):
             continue
-
-    if not isinstance(procs, int):
-        procs = 1
 
     return procs
 

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -149,6 +149,28 @@ def logfiles_to_process(args):
                     DebugPrint(5, "Processing logfile %s" % logfile)
                     yield os.path.join(arg, logfile)
 
+
+def get_num_procs(job_ad):
+    """Get the number of processors of a JobAd from one of the following attributes:
+
+    1. MachineAttrCpus0
+    2. MATCH_EXP_JOB_GLIDEIN_Cpus
+    3. RequestCpus
+
+    If none of the above are set or do not evaluate to an integer, return 1
+    """
+    procs = ''
+    for attr in ['RequestCpus', 'MATCH_EXP_JOB_GLIDEIN_Cpus', 'MachineAttrCpus0']:
+        try:
+            procs = int(job_ad.eval(attr))
+        except (KeyError, ValueError):
+            continue
+
+    if not isinstance(procs, int):
+        procs = 1
+
+    return procs
+
 condor_history_re = re.compile("^history.(\d+)\.(\d+)")
 def main():
     try:
@@ -650,14 +672,7 @@ def classadToJUR(classad):
             DebugPrint(5, "Arbitrary attribute: %s found with value %s" % (arbitraryAttr, classad.eval(arbitraryAttr)))
             r.AdditionalInfo(arbitraryAttr, classad.eval(arbitraryAttr))
     ########################################################################################
-    if 'MachineAttrCpus0' in classad:
-        r.Processors(classad['MachineAttrCpus0'], metric="max")
-    elif 'MATCH_EXP_JOB_GLIDEIN_Cpus' in classad:
-        r.Processors(int(classad['MATCH_EXP_JOB_GLIDEIN_Cpus']), metric="max")
-    elif 'RequestCpus' in classad:
-        r.Processors(classad['RequestCpus'], metric="max")
-    else:
-        r.Processors(1, metric="max")
+    r.Processors(get_num_procs(classad), metric="max")
 
     # Set the Gpus
     # There are many different spellings of requestgpus, RequestGpus, RequestGpus

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -xe
+
+set +e
+python -m unittest discover --help
+discover_available=$?
+set -e
+
+if [ $discover_available -eq 0 ]; then
+    # call tests directly
+    python -m unittest discover test
+else
+    python test/test_condor_meter.py
+fi

--- a/test/test_condor_meter.py
+++ b/test/test_condor_meter.py
@@ -14,16 +14,14 @@ class CondorMeterTests(unittest.TestCase):
         """get_num_procs() has an order of preferred attributes
         """
         jobad = classad.ClassAd()
-        for attr, val in [('RequestCpus', 1),
-                          ('MATCH_EXP_JOB_GLIDEIN_Cpus', 2),
-                          ('MachineAttrCpus0', 3)]:
+        for attr, val in [(x, condor_meter.PROC_ATTRS.index(x)) for x in reversed(condor_meter.PROC_ATTRS)]:
             jobad[attr] = val
             self.assertEquals(condor_meter.get_num_procs(jobad), val)
 
     def test_proc_expr(self):
         """get_num_procs() should be able to handle attributes set to ClassAd expressions
         """
-        for attr in ['MachineAttrCpus0', 'MATCH_EXP_JOB_GLIDEIN_Cpus', 'RequestCpus']:
+        for attr in condor_meter.PROC_ATTRS:
             jobad = classad.ClassAd()
             jobad[attr] = classad.ExprTree('2 + 2')
             procs = condor_meter.get_num_procs(jobad)
@@ -32,7 +30,7 @@ class CondorMeterTests(unittest.TestCase):
     def test_proc_int(self):
         """The Processors field should always return an integer
         """
-        for attr in ['MachineAttrCpus0', 'MATCH_EXP_JOB_GLIDEIN_Cpus', 'RequestCpus']:
+        for attr in condor_meter.PROC_ATTRS:
             jobad = classad.ClassAd()
             jobad[attr] = 'broken attribute'
             procs = condor_meter.get_num_procs(jobad)

--- a/test/test_condor_meter.py
+++ b/test/test_condor_meter.py
@@ -10,6 +10,16 @@ class CondorMeterTests(unittest.TestCase):
     """Unit tests for the HTCondor Gratia probe
     """
 
+    def test_proc_attr_order(self):
+        """get_num_procs() has an order of preferred attributes
+        """
+        jobad = classad.ClassAd()
+        for attr, val in [('RequestCpus', 1),
+                          ('MATCH_EXP_JOB_GLIDEIN_Cpus', 2),
+                          ('MachineAttrCpus0', 3)]:
+            jobad[attr] = val
+            self.assertEquals(condor_meter.get_num_procs(jobad), val)
+
     def test_proc_expr(self):
         """get_num_procs() should be able to handle attributes set to ClassAd expressions
         """

--- a/test/test_condor_meter.py
+++ b/test/test_condor_meter.py
@@ -1,0 +1,20 @@
+#!/bin/env python
+
+import unittest
+import classad
+
+from condor import condor_meter
+
+class CondorMeterTests(unittest.TestCase):
+    """Unit tests for the HTCondor Gratia probe
+    """
+
+    def test_proc_expr(self):
+        """get_num_procs() should be able to handle attributes set to ClassAd expressions
+        """
+        self.fail()
+
+    def test_proc_int(self):
+        """The Processors field should always return an integer
+        """
+        self.fail()

--- a/test/test_condor_meter.py
+++ b/test/test_condor_meter.py
@@ -5,6 +5,7 @@ import classad
 
 from condor import condor_meter
 
+
 class CondorMeterTests(unittest.TestCase):
     """Unit tests for the HTCondor Gratia probe
     """
@@ -12,9 +13,17 @@ class CondorMeterTests(unittest.TestCase):
     def test_proc_expr(self):
         """get_num_procs() should be able to handle attributes set to ClassAd expressions
         """
-        self.fail()
+        for attr in ['MachineAttrCpus0', 'MATCH_EXP_JOB_GLIDEIN_Cpus', 'RequestCpus']:
+            jobad = classad.ClassAd()
+            jobad[attr] = classad.ExprTree('2 + 2')
+            procs = condor_meter.get_num_procs(jobad)
+            self.assertEquals(procs, 4)
 
     def test_proc_int(self):
         """The Processors field should always return an integer
         """
-        self.fail()
+        for attr in ['MachineAttrCpus0', 'MATCH_EXP_JOB_GLIDEIN_Cpus', 'RequestCpus']:
+            jobad = classad.ClassAd()
+            jobad[attr] = 'broken attribute'
+            procs = condor_meter.get_num_procs(jobad)
+            self.assertIsInstance(procs, int)


### PR DESCRIPTION
@djw8605 @edquist this is a WIP branch that modifies the logic for setting the `Processor` field for records coming from the condor probe. The big things are:

1. ClassAd expressions are evaluated to address [SOFTWARE-3474](https://opensciencegrid.atlassian.net/browse/SOFTWARE-3474)
1. Ensures that `Processors` is set to 1 if the ClassAd attributes don't return an integer when evaluated

I'm marking this as `do-not-merge` and holding off on requesting a review because I'm still working through Travis issues and I reserve the right to squash and force-push to my branch at any point.

However, I wanted to get a conversation going about setting the default CPUs to 1. I believe this was the intention of the previous logic but it may serve to obfuscate issues in the future by creating subtly broken records. That however, may be preferable to the current behavior of creating completely broken records, which is the case for hosted CEs. @osg-cat may have some opinions on this -- maybe we can set a `ProcessorsError` field to an informative for records where the expected attributes do not evaluate properly?