### PR TITLE
include non-aggregate SELECT columns in GROUP BY (SOFTWARE-3724)

### DIFF
--- a/slurm/SlurmProbe.py
+++ b/slurm/SlurmProbe.py
@@ -279,7 +279,7 @@ class SlurmAcct_v1(SlurmAcctBase):
             FROM %(cluster)s_job_table as j
             LEFT JOIN %(cluster)s_assoc_table AS a ON j.id_assoc = a.id_assoc
             WHERE %(where)s
-            GROUP BY id_user
+            GROUP BY j.id_user, j.id_group, a.acct, a.user
             ORDER BY time_end
         ''' % { 'cluster': self._cluster, 'where': where }
 
@@ -343,7 +343,17 @@ class SlurmAcct_v1(SlurmAcctBase):
             FROM %(cluster)s_job_table as j
             LEFT JOIN %(cluster)s_assoc_table AS a ON j.id_assoc = a.id_assoc
             WHERE %(where)s
-            GROUP BY id_job
+            GROUP BY j.id_job
+                   , j.exit_code
+                   , j.id_group
+                   , j.id_user
+                   , j.job_name
+                   , j.cpus_alloc
+                   , j.partition
+                   , j.state
+                   , a.acct
+                   , a.user
+                   , j.job_db_inx
             HAVING %(having)s
             ORDER BY j.time_end
         ''' % { 'cluster': self._cluster, 'where': where, 'having': having,
@@ -403,7 +413,7 @@ class SlurmAcct_v2(SlurmAcctBase):
             FROM %(cluster)s_job_table as j
             LEFT JOIN %(cluster)s_assoc_table AS a ON j.id_assoc = a.id_assoc
             WHERE %(where)s
-            GROUP BY id_user
+            GROUP BY j.id_user, j.id_group, a.acct, a.user
             ORDER BY time_end
         ''' % { 'cluster': self._cluster, 'where': where }
 
@@ -477,7 +487,17 @@ class SlurmAcct_v2(SlurmAcctBase):
             FROM %(cluster)s_job_table as j
             LEFT JOIN %(cluster)s_assoc_table AS a ON j.id_assoc = a.id_assoc
             WHERE %(where)s
-            GROUP BY id_job
+            GROUP BY j.id_job
+                   , j.exit_code
+                   , j.id_group
+                   , j.id_user
+                   , j.job_name
+                   , j.tres_alloc
+                   , j.partition
+                   , j.state
+                   , a.acct
+                   , a.user
+                   , j.job_db_inx
             HAVING %(having)s
             ORDER BY j.time_end
         ''' % { 'cluster': self._cluster, 'where': where, 'having': having,


### PR DESCRIPTION
Required by sql standard, and started being enforced in mysql 5.7

https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html

This came up when Bockjoo was testing gratia-probe-1.20.9-1 with Slurm v18.  His newer mysql 5.7.x was rejecting the query without all the non-aggregate select columns in the group by.

Note that this is basically the same thing we tried to fix in #50, which we thought was due to another schema change in Slurm v19.  However it seems clear enough now that the issue was just due to the mysql upgrade - it's not specific to Slurm v19.

So this new PR actually supersedes #50, since the GROUP BY fix should not be limited to v19.