### PR TITLE
log unhandled errors (SOFTWARE-3877)

### DIFF
--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -936,5 +936,13 @@ def send_alternate_records_child(info, record_list):
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SystemExit:
+        raise
+    except KeyboardInterrupt:
+        raise
+    except Exception, e:
+        DebugPrint(-1, "ERROR: Unexpected error encountered: %s" % e)
+        raise
 

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -307,8 +307,14 @@ def process_history_dirs(dirs):
         # Make sure the filename is in a reasonable format
         m = condor_history_re.match(logfile)
         if m:
-            cnt_submit, cnt_found, cnt_alternate = process_history_file(log)
-            if cnt_submit + cnt_alternate == cnt_found and (cnt_submit > 0 or cnt_alternate > 0):
+            e = None
+            try:
+                cnt_submit, cnt_found, cnt_alternate = process_history_file(log)
+            except ValueError, e:
+                DebugPrint(1, "Failed to parse log file: %s\nError was: %s" % (log, e))
+                cnt_submit, cnt_found, cnt_alternate = 0, 0, 0
+
+            if not e and cnt_submit + cnt_alternate == cnt_found and (cnt_submit > 0 or cnt_alternate > 0):
                 DebugPrint(5, "Processed %i ClassAds from file %s" % (cnt_submit, log))
             else:
                 DebugPrint(2, "Unable to process ClassAd from file (will add to quarantine): %s.  Submit count %d; found count %d" % (log, cnt_submit, cnt_found))

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -944,5 +944,6 @@ if __name__ == "__main__":
         raise
     except Exception, e:
         DebugPrint(-1, "ERROR: Unexpected error encountered: %s" % e)
+        DebugPrintTraceback()
         raise
 


### PR DESCRIPTION
As encountered in SOFTWARE-3877, a history file parsing error does not get caught anywhere in the condor probe, and so the exception / traceback does not get logged to the gratia logs.  (condor_meter is run by cron, so any stderr output goes to ..? probably syslog or root email.)

This is a first step to log unexpected failures to the gratia logs.

Beyond this it would be good to individually catch history files that cause parse errors.