### PR TITLE
Set /var/lib/gratia/tmp permissions to 1777 (SOFTWARE-3975)

### DIFF
--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -2,7 +2,7 @@ Name:               gratia-probe
 Summary:            Gratia OSG accounting system probes
 Group:              Applications/System
 Version:            1.20.12
-Release:            1%{?dist}
+Release:            2%{?dist}
 
 License:            GPL
 Group:              Applications/System
@@ -261,7 +261,7 @@ install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gratia
   # Set up var area
   install -d $RPM_BUILD_ROOT%{_localstatedir}/lib/gratia/
   install -d $RPM_BUILD_ROOT%{_localstatedir}/lib/gratia/{tmp,data,data/quarantine,logs}
-  chmod 1777  $RPM_BUILD_ROOT%{_localstatedir}/lib/gratia/data
+  chmod 1777  $RPM_BUILD_ROOT%{_localstatedir}/lib/gratia/{data,tmp}
 
 
   # PBS / LSF probe
@@ -897,6 +897,9 @@ The dCache storagegroup probe for the Gratia OSG accounting system.
 
 
 %changelog
+* Wed Jan 22 2020 Carl Edquist <edquist@cs.wisc.edu> - 1.20.12-2
+- Set /var/lib/gratia/tmp permissions to 1777 (SOFTWARE-3975)
+
 * Fri Dec 13 2019 Carl Edquist <edquist@cs.wisc.edu> - 1.20.12-1
 - Quarantine files with parse errors, log unhandled errors (SOFTWARE-3877)
 


### PR DESCRIPTION
The motivation here is to allow a condor daemon to run the probe, rather than just root.  There is a precondition check that /var/lib/gratia/tmp be writable for any of the probes to run (even if the specific probe does not use that directory).

Two options discussed for this were (1) making a `gratia` unix group for everything under /var/lib/gratia, making that tree group-writable, and then adding any users that need to run the probes (eg `condor`) to this new group, or (2) just giving /var/lib/gratia/tmp global sticky-write permissions like /tmp.

(2) seemed more straightforward.  So unless there's some security concern, I'm thinking just to go that route.