### PR TITLE
Use interpolation for cluster with version less than slurm 18 (SOFTWARE-4055)

### DIFF
--- a/slurm/SlurmProbe.py
+++ b/slurm/SlurmProbe.py
@@ -310,7 +310,7 @@ class SlurmAcct_v1(SlurmAcctBase):
                 FROM `%(cluster)s_step_table` s
                 WHERE s.job_db_inx = j.job_db_inx
                 /* Note: Will underreport mem for jobs with simultaneous steps */
-              )'''
+              )''' % {'cluster': self._cluster }
         else:
             max_rss = '''MAX(j.mem_req)'''
 
@@ -454,7 +454,7 @@ class SlurmAcct_v2(SlurmAcctBase):
                 FROM `%(cluster)s_step_table` s
                 WHERE s.job_db_inx = j.job_db_inx
                 /* Note: Will underreport mem for jobs with simultaneous steps */
-              )'''
+              )''' % {'cluster': self._cluster }
         else:
             max_rss = '''MAX(j.mem_req)'''
 


### PR DESCRIPTION
@jthiltges could you take a look at this as well.  I think the string interpolation needs to happen in 2 steps, not just all at once.