### PR TITLE
Revert setting /var/lib/gratia/tmp permissions to 1777 (SOFTWARE-3975)

### DIFF
--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -2,7 +2,7 @@ Name:               gratia-probe
 Summary:            Gratia OSG accounting system probes
 Group:              Applications/System
 Version:            1.20.12
-Release:            2%{?dist}
+Release:            1%{?dist}
 
 License:            GPL
 Group:              Applications/System
@@ -261,7 +261,7 @@ install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gratia
   # Set up var area
   install -d $RPM_BUILD_ROOT%{_localstatedir}/lib/gratia/
   install -d $RPM_BUILD_ROOT%{_localstatedir}/lib/gratia/{tmp,data,data/quarantine,logs}
-  chmod 1777  $RPM_BUILD_ROOT%{_localstatedir}/lib/gratia/{data,tmp}
+  chmod 1777  $RPM_BUILD_ROOT%{_localstatedir}/lib/gratia/data
 
 
   # PBS / LSF probe
@@ -897,9 +897,6 @@ The dCache storagegroup probe for the Gratia OSG accounting system.
 
 
 %changelog
-* Wed Jan 22 2020 Carl Edquist <edquist@cs.wisc.edu> - 1.20.12-2
-- Set /var/lib/gratia/tmp permissions to 1777 (SOFTWARE-3975)
-
 * Fri Dec 13 2019 Carl Edquist <edquist@cs.wisc.edu> - 1.20.12-1
 - Quarantine files with parse errors, log unhandled errors (SOFTWARE-3877)
 


### PR DESCRIPTION
This reverts commit 5db45c3c387d840268a4f44b187e8dc49dc04618.

we can set
```
    WorkingFolder="/var/lib/gratia/tmp"
```
instead for non-root users