### PR TITLE
allow non-word characters in cluster name (SOFTWARE-4032)

### DIFF
--- a/slurm/SlurmProbe.py
+++ b/slurm/SlurmProbe.py
@@ -204,7 +204,7 @@ class SlurmAcctBase(object):
     def __init__(self, conn, cluster, slurm_version):
         self._conn = conn
 
-        cluster = re.sub('\W+', '', cluster)
+        cluster = re.sub(r'[`\0]', '', cluster)
         self._cluster = cluster
         self._slurm_version = slurm_version
 


### PR DESCRIPTION
the only invalid characters really are the backtick and a nul byte - the rest should be ok since the cluster name is escaped in backticks when it's used.