### PR TITLE
add python2/3 compat for pbs-lsf (SOFTWARE-4287)

### DIFF
--- a/pbs-lsf/pbs-lsf
+++ b/pbs-lsf/pbs-lsf
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import sys
 
 import gratia.common.Gratia as Gratia
@@ -13,6 +15,6 @@ if __name__ == '__main__':
                 if (len(sys.argv) == 4) and sys.argv[2] and sys.argv[3]:
                         Gratia.RegisterService(sys.argv[2], sys.argv[3])
                 Gratia.Initialize()
-		print Gratia.SendXMLFiles(sys.argv[1], True, "Batch")
+		print(Gratia.SendXMLFiles(sys.argv[1], True, "Batch"))
 	else:
-		print "pbs-lsf.py: No records directory specified\n"
+		print("pbs-lsf.py: No records directory specified\n")


### PR DESCRIPTION
@matyasselmeci looks like i forgot the "2" part of python2/3 compat in #61 