### PR TITLE
convert condor_meter to be python2/3 compatible (SOFTWARE-4283)

### DIFF
--- a/common/gratia/common/connect_utils.py
+++ b/common/gratia/common/connect_utils.py
@@ -276,9 +276,7 @@ def postRequest(myconnection, to, what, headers):
     myconnection.request('POST', to, what, headers)
     DebugPrint(4, 'DEBUG: POST: OK')
     DebugPrint(4, 'DEBUG: Read response')
-    responseString = myconnection.getresponse().read()
-    if not isinstance(responseString, str):
-        responseString = responseString.decode(errors='ignore')
+    responseString = utils.bytes2str(myconnection.getresponse().read())
     DebugPrint(4, 'DEBUG: Read response: OK')
     
     signal.alarm(0)

--- a/common/gratia/common/probe_config.py
+++ b/common/gratia/common/probe_config.py
@@ -151,9 +151,7 @@ class ProbeConfiguration:
                                        'not really')])
         headers = {'Content-type': 'application/x-www-form-urlencoded'}
         qconnection.request('POST', self.get_RegistrationService(), queryString, headers)
-        responseString = qconnection.getresponse().read()
-        if not isinstance(responseString, str):
-            responseString = responseString.decode(errors='ignore')
+        responseString = utils.bytes2str(qconnection.getresponse().read())
         resplist = responseString.split(':')
         if len(resplist) == 3 and resplist[0] == 'ok':
 

--- a/common/gratia/common/utils.py
+++ b/common/gratia/common/utils.py
@@ -141,3 +141,7 @@ def genDefaultProbeName():
     f.close()
     return meterName
 
+# for python2/3 compat, when you have a bytes and want a str
+def bytes2str(s):
+    return s if isinstance(s, str) else s.decode(errors='ignore')
+

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -24,6 +24,7 @@ import gratia.common.GratiaWrapper as GratiaWrapper
 import gratia.common.Gratia as Gratia
 import gratia.common.file_utils as file_utils
 import gratia.common.config as config
+import gratia.common.utils as utils
 
 import classad as classadLib
 
@@ -835,7 +836,7 @@ def htcondor_configured():
             args = condor_config_binary + ' ' + ' '.join(condor_config_val_args)
             DebugPrint(4, 'Running command to check condor config: ' + args)
             cmd = subprocess.Popen(args, stdout=subprocess.PIPE, shell=True)
-        (cmd_stdout, cmd_stderr) = cmd.communicate()
+        (cmd_stdout, cmd_stderr) = map(utils.bytes2str, cmd.communicate())
         # cmd_stdout contains the directory path, removing spaces
         # It will always be a string even if returncode != 0 
         cmd_stdout = cmd_stdout.strip()

--- a/slurm/SlurmProbe.py
+++ b/slurm/SlurmProbe.py
@@ -22,6 +22,7 @@ import subprocess
 from gratia.common.Gratia import DebugPrint
 import gratia.common.GratiaWrapper as GratiaWrapper
 import gratia.common.Gratia as Gratia
+import gratia.common.utils as utils
 
 import MySQLdb
 import MySQLdb.cursors
@@ -143,9 +144,7 @@ class SlurmProbe:
 
         cmd = [prog, "--version"]
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        output, _ = p.communicate()
-        if not isinstance(output, str):
-            output = output.decode(errors="ignore")
+        output, _ = map(utils.bytes2str, p.communicate())
 
         if p.returncode != 0:
             raise Exception("Unable to invoke %s" % cmd)


### PR DESCRIPTION
And, incidentally, introduce utils.bytes2str helper for py2/3 compat, for use in condor_meter, and other already converted spots

...

Other than decoding the output from Popen.communicate(), i don't see anything non python3 in condor_meter