### PR TITLE
fix stderr handling in communicate() (SOFTWARE-4348)

### DIFF
--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -836,7 +836,7 @@ def htcondor_configured():
             args = condor_config_binary + ' ' + ' '.join(condor_config_val_args)
             DebugPrint(4, 'Running command to check condor config: ' + args)
             cmd = subprocess.Popen(args, stdout=subprocess.PIPE, shell=True)
-        (cmd_stdout, cmd_stderr) = map(utils.bytes2str, cmd.communicate())
+        cmd_stdout = utils.bytes2str(cmd.communicate()[0])
         # cmd_stdout contains the directory path, removing spaces
         # It will always be a string even if returncode != 0 
         cmd_stdout = cmd_stdout.strip()

--- a/slurm/SlurmProbe.py
+++ b/slurm/SlurmProbe.py
@@ -144,7 +144,7 @@ class SlurmProbe:
 
         cmd = [prog, "--version"]
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        output, _ = map(utils.bytes2str, p.communicate())
+        output = utils.bytes2str(p.communicate()[0])
 
         if p.returncode != 0:
             raise Exception("Unable to invoke %s" % cmd)


### PR DESCRIPTION
since stderr is not captured, communicate returns None for stderr,
which is not handled by bytes2str.  The stderr variables here are unused,
so just drop them.