### PR TITLE
fix python3 packaging deps for el7 vs el8 (SOFTWARE-4398)

### DIFF
--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -33,14 +33,16 @@ ExcludeArch: noarch
 %if 0%{?rhel} >= 7
 %global __python /usr/bin/python3
 %global condor_python   python3-condor
-%global python_mysql    python36-mysql
 %global python_psycopg2 python3-psycopg2
-%global python_tz       python36-pytz
 
 %if 0%{?rhel} >= 8
 %global python_openssl  python3-pyOpenSSL
+%global python_mysql    python3-mysql
+%global python_tz       python3-pytz
 %else
 %global python_openssl  python36-pyOpenSSL
+%global python_mysql    python36-mysql
+%global python_tz       python36-pytz
 %endif
 
 %else

--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -34,9 +34,15 @@ ExcludeArch: noarch
 %global __python /usr/bin/python3
 %global condor_python   python3-condor
 %global python_mysql    python36-mysql
-%global python_openssl  python36-pyOpenSSL
 %global python_psycopg2 python3-psycopg2
 %global python_tz       python36-pytz
+
+%if 0%{?rhel} >= 8
+%global python_openssl  python3-pyOpenSSL
+%else
+%global python_openssl  python36-pyOpenSSL
+%endif
+
 %else
 %global condor_python   python2-condor
 %global python_mysql    MySQL-python


### PR DESCRIPTION
Derp, discovered in testing[1], the python openssl package name changes between el7/el8, and there do not appear to be any common virtual capabilities provided...

[1] https://osg-sw-submit.chtc.wisc.edu/tests/20201216-1241/packages.html