### PR TITLE
python3 build fixes for el8 (SOFTWARE-4398)

### DIFF
--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -10,6 +10,10 @@ Vendor:             The Open Science Grid <http://www.opensciencegrid.org/>
 BuildRequires:      make
 BuildRequires:      gcc-c++
 
+%if 0%{?rhel} >= 7
+BuildRequires:      python3
+%endif
+
 # just do a single arch build until we drop the compiled tool in pbs-lsf
 ExcludeArch: noarch
 
@@ -409,8 +413,7 @@ fi
 %attr(-,gratia,gratia) %{_localstatedir}/log/gratia/
 %dir %{_sysconfdir}/gratia
 %{_localstatedir}/lock/gratia/
-%if 0%{?rhel} == 7
-# XXX: for some reason this __pycache__ does not appear in el8
+%if 0%{?rhel} >= 7
 %{python_sitelib}/gratia/__pycache__/
 %endif
 %{python_sitelib}/gratia/__init__.py*


### PR DESCRIPTION
apparently python3 does not come in automatically, which is needed for `__python` to expand `python_sitelib` correctly.  Also, this fixes the oddity with `__pycache__` previously not showing up in el8, which now needs to be included in the packaging as well.

This fixes the el8 build in scratch builds
https://koji.opensciencegrid.org/koji/taskinfo?taskID=325677
https://koji.opensciencegrid.org/koji/taskinfo?taskID=325676
