### PR TITLE
Send daily partial records (SOFTWARE-4404)

### DIFF
--- a/osg-pilot-container/osgpilot_meter
+++ b/osg-pilot-container/osgpilot_meter
@@ -36,9 +36,10 @@ LOCAL_USER = "osgvo-container-pilot"
 
 grid_type = "OSG"
 
-DONE_IF_NOT_SEEN_AFTER = 1 * 60 * 60;
-
-POLL_INTERVAL = 15 * 60  # seconds
+# in seconds
+DONE_IF_NOT_SEEN_AFTER =  1 * 60 * 60
+POLL_INTERVAL          = 15 * 60
+PARTIAL_RECORD_CUTOFF  = 24 * 60 * 60
 
 # log levels
 CRITICAL = 0
@@ -375,6 +376,10 @@ def detect_finished_jobs(sqldb, current_ts):
 
     DebugPrint(INFO, "- inserted %s rows into outbox" % rc1)
     DebugPrint(INFO, "- deleted %s rows from jobs" % rc2)
+
+
+def report_partial_jobs(sqldb):
+    pass
 
 
 def update_active_jobs(sqldb):

--- a/osg-pilot-container/osgpilot_meter
+++ b/osg-pilot-container/osgpilot_meter
@@ -477,8 +477,8 @@ def detect_and_update_partial_jobs(sqldb):
          where last_updated - DaemonStartTime >= {partial_record_cutoff};
     """.format(partial_record_cutoff=PARTIAL_RECORD_CUTOFF)
 
-    rc1 = sqldb.execute(insert_sql, (dead_cutoff,)).rowcount
-    rc2 = sqldb.execute(update_sql, (dead_cutoff,)).rowcount
+    rc1 = sqldb.execute(insert_sql).rowcount
+    rc2 = sqldb.execute(update_sql).rowcount
 
     DebugPrint(INFO, "- inserted %s rows into outbox" % rc1)
     DebugPrint(INFO, "- updated %s rows from jobs" % rc2)

--- a/osg-pilot-container/osgpilot_meter
+++ b/osg-pilot-container/osgpilot_meter
@@ -219,29 +219,6 @@ schema_sql = [
 
 
     """
-    create view cutoff as
-    select *
-      from updates
-     where elapsed_interval >= ?
-    """,
-
-
-    """
-    create view cutoff2 as
-    select DaemonStartTime                as StartTime
-         , last_updated                   as EndTime
-         , last_updated - DaemonStartTime as WallDuration
-         , total_cpu                      as CpuDuration
-         , Cpus                           as Processors
-         , MemoryUsage                    as Memory
-         , ifnull(GLIDEIN_Site,
-                  GLIDEIN_ResourceName)   as SiteName
-         , Machine                        as MachineName
-      from cutoff;
-    """,
-
-
-    """
     create view updated as
     select *
          , next_CPUsUsage * elapsed_interval as next_cpu
@@ -260,6 +237,23 @@ schema_sql = [
         on a.name = b.name
      where a.name is null;
     """,
+
+
+    """
+    create view cutoff as
+    select DaemonStartTime                as StartTime
+         , last_updated                   as EndTime
+         , last_updated - DaemonStartTime as WallDuration
+         , total_cpu                      as CpuDuration
+         , Cpus                           as Processors
+         , MemoryUsage                    as Memory
+         , ifnull(GLIDEIN_Site,
+                  GLIDEIN_ResourceName)   as SiteName
+         , Machine                        as MachineName
+      from jobs
+     where last_updated - DaemonStartTime >= {partial_record_cutoff};
+    """.format(partial_record_cutoff=PARTIAL_RECORD_CUTOFF),
+
 ]
 
 

--- a/osg-pilot-container/osgpilot_meter
+++ b/osg-pilot-container/osgpilot_meter
@@ -496,7 +496,8 @@ def query_and_update_db(opts):
 
     detect_finished_jobs(sqldb, current_ts)
     update_active_jobs(sqldb)
-    detect_new_jobs(sqldb, current_ts) # XXX: this step must go last
+    detect_new_jobs(sqldb, current_ts) # XXX: must go after update_active_jobs
+    detect_and_update_partial_jobs(sqldb)
     sqldb.commit()
 
 

--- a/osg-pilot-container/osgpilot_meter
+++ b/osg-pilot-container/osgpilot_meter
@@ -482,6 +482,9 @@ def detect_and_update_partial_jobs(sqldb):
 
     DebugPrint(INFO, "- inserted %s rows into outbox" % rc1)
     DebugPrint(INFO, "- updated %s rows from jobs" % rc2)
+    if rc1 != rc2:
+        DebugPrint(ERROR, "Counts do not match for partial records"
+                          " inserted into inbox and updated from jobs")
 
 
 def query_and_update_db(opts):

--- a/osg-pilot-container/osgpilot_meter
+++ b/osg-pilot-container/osgpilot_meter
@@ -219,6 +219,29 @@ schema_sql = [
 
 
     """
+    create view cutoff as
+    select *
+      from updates
+     where elapsed_interval >= ?
+    """,
+
+
+    """
+    create view cutoff2 as
+    select DaemonStartTime                as StartTime
+         , last_updated                   as EndTime
+         , last_updated - DaemonStartTime as WallDuration
+         , total_cpu                      as CpuDuration
+         , Cpus                           as Processors
+         , MemoryUsage                    as Memory
+         , ifnull(GLIDEIN_Site,
+                  GLIDEIN_ResourceName)   as SiteName
+         , Machine                        as MachineName
+      from cutoff;
+    """,
+
+
+    """
     create view updated as
     select *
          , next_CPUsUsage * elapsed_interval as next_cpu

--- a/osg-pilot-container/osgpilot_meter
+++ b/osg-pilot-container/osgpilot_meter
@@ -458,7 +458,7 @@ def detect_new_jobs(sqldb, current_ts):
     DebugPrint(INFO, "- deleted %s rows from inbox" % rc2)
 
 
-def report_partial_jobs(sqldb):
+def detect_and_update_partial_jobs(sqldb):
     DebugPrint(INFO, "Reporting and breaking up partial jobs")
 
     insert_sql = """

--- a/osg-pilot-container/osgpilot_meter
+++ b/osg-pilot-container/osgpilot_meter
@@ -378,6 +378,7 @@ def detect_finished_jobs(sqldb, current_ts):
         select *
           from finished2
          where EndTime < ?
+           and WallDuration > 0;
     """ % ", ".join(SEND_ATTRS)
 
     delete_sql = """

--- a/osg-pilot-container/osgpilot_meter
+++ b/osg-pilot-container/osgpilot_meter
@@ -395,10 +395,6 @@ def detect_finished_jobs(sqldb, current_ts):
     DebugPrint(INFO, "- deleted %s rows from jobs" % rc2)
 
 
-def report_partial_jobs(sqldb):
-    pass
-
-
 def update_active_jobs(sqldb):
     DebugPrint(INFO, "Updating active jobs")
 
@@ -461,6 +457,30 @@ def detect_new_jobs(sqldb, current_ts):
     DebugPrint(INFO, "- inserted %s rows into jobs" % rc1)
     DebugPrint(INFO, "- deleted %s rows from inbox" % rc2)
 
+
+def report_partial_jobs(sqldb):
+    DebugPrint(INFO, "Reporting and breaking up partial jobs")
+
+    insert_sql = """
+        insert into outbox (%s)
+        select *
+          from cutoff
+    """ % ", ".join(SEND_ATTRS)
+
+    # reset aggregates
+    update_sql = """
+        update jobs
+           set DaemonStartTime = last_updated,
+               total_cpu = 0,
+               MemoryUsage = 0
+         where last_updated - DaemonStartTime >= {partial_record_cutoff};
+    """.format(partial_record_cutoff=PARTIAL_RECORD_CUTOFF)
+
+    rc1 = sqldb.execute(insert_sql, (dead_cutoff,)).rowcount
+    rc2 = sqldb.execute(update_sql, (dead_cutoff,)).rowcount
+
+    DebugPrint(INFO, "- inserted %s rows into outbox" % rc1)
+    DebugPrint(INFO, "- updated %s rows from jobs" % rc2)
 
 
 def query_and_update_db(opts):


### PR DESCRIPTION
The concept here is:

- If a job has been active for > 1 day:
  - send it as if it were completed
  - reset its start time, total cpu, and max memory aggregates

Note that this gives rolling updates throughout the day as partial jobs cross their 24-hour lifetimes.  This is not quite the same thing as having a separate "daily flush" code path, where all unfinished jobs would get sent and reset as if they were finished, regardless of their lifetime.  But the main point is the same, that the progress for each job will be reported daily.

I think the code is likely complete at this point, but given that it's entirely untested i am marking this PR as a draft.