### PR TITLE
fix python3 integer division for duration formatter

### DIFF
--- a/common/gratia/common/record.py
+++ b/common/gratia/common/record.py
@@ -123,9 +123,9 @@ class Record(object):
         seconds = int(value * 100) % 6000 / 100.0
         value = int((value - seconds) / 60)
         minutes = value % 60
-        value = (value - minutes) / 60
+        value = (value - minutes) // 60
         hours = value % 24
-        value = (value - hours) / 24
+        value = (value - hours) // 24
         result = 'P'
         if value > 0:
             result = result + str(value) + 'D'


### PR DESCRIPTION
value, minutes, and hours here are expected to be ints, but '/' does
float division in python3