### PR TITLE
Avoid re.split warning for el8 (SOFTWARE-4283)

### DIFF
--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -677,7 +677,7 @@ def classadToJUR(classad):
     # Code added to send to arbitrary Ads SOFTWARE-2714
     ArbitraryJobAttrs = str(GratiaCore.Config.getConfigAttribute("ExtraAttributes"))
     DebugPrint(5, "Arbitrary Job Attributes: %s" % ArbitraryJobAttrs)
-    ArbitraryAttrslist = re.split(",?\s?", ArbitraryJobAttrs)
+    ArbitraryAttrslist = re.split(r'[,\s]+', ArbitraryJobAttrs)
     DebugPrint(0, "ArbritaryList: %s" % ArbitraryAttrslist)
     for arbitraryAttr in ArbitraryAttrslist:
         if arbitraryAttr in classad:

--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -1,7 +1,7 @@
 Name:               gratia-probe
 Summary:            Gratia OSG accounting system probes
 Group:              Applications/System
-Version:            1.22.2
+Version:            1.22.3
 Release:            1%{?dist}
 License:            GPL
 URL:                http://sourceforge.net/projects/gratia/
@@ -956,7 +956,10 @@ The dCache storagegroup probe for the Gratia OSG accounting system.
 
 
 %changelog
-* Thu Jan 07 2021  <karo@cs.wisc.edu> - 1.22.2-1
+* Tue Jan 19 2021  <edquist@cs.wisc.edu> - 1.22.3-1
+- Fix re.split warning for el8 (SOFTWARE-4283)
+
+* Thu Jan 07 2021  <edquist@cs.wisc.edu> - 1.22.2-1
 - Fix duration formatting in xml for python3 (SOFTWARE-4416)
 - Report partial jobs for osg pilot container probe (SOFTWARE-4404)
 


### PR DESCRIPTION
the new re.split pattern works for me in an el8 container