### PR TITLE
add 'GratiaVersion' to UsageRecords (SOFTWARE-4455)

### DIFF
--- a/common/gratia/common/Gratia.py
+++ b/common/gratia/common/Gratia.py
@@ -59,6 +59,7 @@ class UsageRecord(record.Record):
     __Njobs = 1
     __NjobsDescription = r''
     __ResourceType = None
+    __GratiaVersion = "%%%RPMVERSION%%%"
 
     def __init__(self, resourceType=None):
 
@@ -444,6 +445,7 @@ class UsageRecord(record.Record):
         self.GenericAddToList('Njobs', str(self.__Njobs), self.__NjobsDescription)
         if self.__ResourceType != None:
             self.Resource('ResourceType', self.__ResourceType)
+        self.GenericAddToList('GratiaVersion', __GratiaVersion, "")
 
     def VerifyUserInfo(self):
         ''' Verify user information: check for LocalUserId and add VOName and ReportableVOName if necessary'''

--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -14,7 +14,11 @@ BuildRequires:      gcc-c++
 BuildRequires:      python3
 %endif
 
+%if 0%{?rhel} < 8
 BuildRequires:      git
+%else
+BuildRequires:      git-core
+%endif
 
 # just do a single arch build until we drop the compiled tool in pbs-lsf
 ExcludeArch: noarch

--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -339,7 +339,7 @@ git_commit_id=$(gzip -d < %{SOURCE0} | git get-tar-commit-id)
 rpmver=%{version}-%{release}.${git_commit_id:0:7}
 find $RPM_BUILD_ROOT%{_datadir}/gratia $RPM_BUILD_ROOT%{python_sitelib} \
   -type f -exec fgrep -ZIle '%%%%%%RPMVERSION%%%%%%' {} + | xargs -0 \
-  perl -wpi -e "s&%%%%%%RPMVERSION%%%%%%&$rpmver&g"
+  sed -i "s&%%%%%%RPMVERSION%%%%%%&$rpmver&g"
 
 install -d $RPM_BUILD_ROOT/%{_localstatedir}/log/gratia
 install -d $RPM_BUILD_ROOT/%{_localstatedir}/lock/gratia

--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -14,6 +14,8 @@ BuildRequires:      gcc-c++
 BuildRequires:      python3
 %endif
 
+BuildRequires:      git
+
 # just do a single arch build until we drop the compiled tool in pbs-lsf
 ExcludeArch: noarch
 
@@ -99,6 +101,10 @@ install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gratia
 %else
     rm common/tmpfiles.d/gratia.conf
 %endif
+
+
+git_commit_id=$(gzip -d < %{SOURCE0} | git get-tar-commit-id)
+
 
   # Obtain files
 
@@ -330,11 +336,7 @@ install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gratia
 
 
 # Burn in the RPM version into the python files.
-rpmver=%{version}-%{release}
-if [[ $GIT_COMMIT_ID ]]; then
-  rpmver=$rpmver.${GIT_COMMIT_ID:0:7}
-fi
-
+rpmver=%{version}-%{release}.${git_commit_id:0:7}
 find $RPM_BUILD_ROOT%{_datadir}/gratia $RPM_BUILD_ROOT%{python_sitelib} \
   -type f -exec fgrep -ZIle '%%%%%%RPMVERSION%%%%%%' {} + | xargs -0 \
   perl -wpi -e "s&%%%%%%RPMVERSION%%%%%%&$rpmver&g"

--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -334,10 +334,10 @@ rpmver=%{version}-%{release}
 if [[ $GIT_COMMIT_ID ]]; then
   rpmver=$rpmver.${GIT_COMMIT_ID:0:7}
 fi
-grep -rIle '%%%%%%RPMVERSION%%%%%%' $RPM_BUILD_ROOT%{_datadir}/gratia $RPM_BUILD_ROOT%{python_sitelib} | while read file; do \
-  perl -wpi.orig -e "s&%%%%%%RPMVERSION%%%%%%&$rpmver&g" "$file" && \
-    rm -fv "$file.orig"
-done
+
+find $RPM_BUILD_ROOT%{_datadir}/gratia $RPM_BUILD_ROOT%{python_sitelib} \
+  -type f -exec fgrep -ZIle '%%%%%%RPMVERSION%%%%%%' {} + | xargs -0 \
+  perl -wpi -e "s&%%%%%%RPMVERSION%%%%%%&$rpmver&g"
 
 install -d $RPM_BUILD_ROOT/%{_localstatedir}/log/gratia
 install -d $RPM_BUILD_ROOT/%{_localstatedir}/lock/gratia

--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -330,8 +330,12 @@ install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gratia
 
 
 # Burn in the RPM version into the python files.
+rpmver=%{version}-%{release}
+if [[ $GIT_COMMIT_ID ]]; then
+  rpmver=$rpmver.${GIT_COMMIT_ID:0:7}
+fi
 grep -rIle '%%%%%%RPMVERSION%%%%%%' $RPM_BUILD_ROOT%{_datadir}/gratia $RPM_BUILD_ROOT%{python_sitelib} | while read file; do \
-  perl -wpi.orig -e 's&%%%%%%RPMVERSION%%%%%%&%{version}-%{release}&g' "$file" && \
+  perl -wpi.orig -e "s&%%%%%%RPMVERSION%%%%%%&$rpmver&g" "$file" && \
     rm -fv "$file.orig"
 done
 


### PR DESCRIPTION
Where GratiaVersion is the rpm version-release followed by the short hash of the git commit.

I did not actually make GratiaVersion a function, since i don't intend that we'd ever call `r.GratiaVersion(...)` explicitly.

Also kind of tidy up the `%%%RPMVERSION%%%` shell find & replace.  (According to me, maybe.)

Scratch builds succeeded: https://koji.opensciencegrid.org/koji/taskinfo?taskID=328312

and in Gratia.py from the built rpm i see

```
    __GratiaVersion = "1.22.3-1.osg35.el8.0cf7ca1"
```
