### PR TITLE
The lack of a log level causes a failure

### DIFF
--- a/common/gratia/common/condor_ce.py
+++ b/common/gratia/common/condor_ce.py
@@ -359,7 +359,7 @@ def queryJob(jobid):
         job_info = queryAllJobs()
         for classad in job_info.values():
             # On failure, there is not much to do - ignore
-            DebugPrint(3, "Creating certinfo file for %s." % \
+            DebugPrint(3, "Creating certinfo file for %s." %
                 classad['GlobalJobId'])
             createCertinfoFile(classad, directory)
         _queryCache = job_info

--- a/common/gratia/common/condor_ce.py
+++ b/common/gratia/common/condor_ce.py
@@ -359,7 +359,7 @@ def queryJob(jobid):
         job_info = queryAllJobs()
         for classad in job_info.values():
             # On failure, there is not much to do - ignore
-            DebugPrint("Creating certinfo file for %s." % \
+            DebugPrint(3, "Creating certinfo file for %s." % \
                 classad['GlobalJobId'])
             createCertinfoFile(classad, directory)
         _queryCache = job_info


### PR DESCRIPTION
Traceback:

```  
File "/usr/lib/python3.6/site-packages/gratia/common/send.py", line 60, in Send
    if not XmlChecker.CheckXmlDoc(xmlDoc, False):
  File "/usr/lib/python3.6/site-packages/gratia/common/xml_utils.py", line 55, in CheckXmlDoc
    content = content + checker(xmlDoc, external, resourceType)
  File "/usr/lib/python3.6/site-packages/gratia/common/xml_utils.py", line 218, in UsageCheckXmldoc
    id_info = CheckAndExtendUserIdentity(xmlDoc, userIdentityNodes[0], namespace, prefix, use_certinfo)
  File "/usr/lib/python3.6/site-packages/gratia/common/xml_utils.py", line 439, in CheckAndExtendUserIdentity
    job_certinfo = condor_ce.queryJob(localJobId)
  File "/usr/lib/python3.6/site-packages/gratia/common/condor_ce.py", line 358, in queryJob
    classad['GlobalJobId'])
  File "/usr/lib/python3.6/site-packages/gratia/common/debug.py", line 59, in DebugPrint
    if  level < int(getGratiaConfig().get_DebugLevel()):
TypeError: '<' not supported between instances of 'str' and 'int'
```