### PR TITLE
Assign exception to separate name (SOFTWARE-4711)

### DIFF
--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -349,7 +349,7 @@ def process_history_file(logfile):
     except IOError as ie:
         DebugPrint(2, "Cannot process %s: (errno=%d) %s" % (logfile, ie.errno,
             ie.strerror))
-        return 0, 0
+        return 0, 0, 0
     added_transient = False
 
     for classad in fd_to_classad(fd):

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -315,7 +315,8 @@ def process_history_dirs(dirs):
             e = None
             try:
                 cnt_submit, cnt_found, cnt_alternate = process_history_file(log)
-            except ValueError as e:
+            except ValueError as ex:
+                e = ex
                 DebugPrint(1, "Failed to parse log file: %s\nError was: %s" % (log, e))
                 cnt_submit, cnt_found, cnt_alternate = 0, 0, 0
 


### PR DESCRIPTION
Apparently in python3 the `target` of an `except ... as target` statement gets cleared after the except block is hit, so the only way to refer to it later is to assign it to a separate name.

Who knew.

https://docs.python.org/3/reference/compound_stmts.html#except

Reported broken by @LincolnBryant (thanks!)