### PR TITLE
Rework ValueError handling (SOFTWARE-4711)

### DIFF
--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -312,14 +312,9 @@ def process_history_dirs(dirs):
         # Make sure the filename is in a reasonable format
         m = condor_history_re.match(logfile)
         if m:
-            e = None
-            try:
-                cnt_submit, cnt_found, cnt_alternate = process_history_file(log)
-            except ValueError as e:
-                DebugPrint(1, "Failed to parse log file: %s\nError was: %s" % (log, e))
-                cnt_submit, cnt_found, cnt_alternate = 0, 0, 0
+            cnt_submit, cnt_found, cnt_alternate = process_history_file_eve(log)
 
-            if not e and cnt_submit + cnt_alternate == cnt_found and (cnt_submit > 0 or cnt_alternate > 0):
+            if cnt_submit + cnt_alternate == cnt_found and cnt_found > 0:
                 DebugPrint(5, "Processed %i ClassAds from file %s" % (cnt_submit, log))
             else:
                 DebugPrint(2, "Unable to process ClassAd from file (will add to quarantine): %s.  Submit count %d; found count %d" % (log, cnt_submit, cnt_found))
@@ -337,6 +332,16 @@ def process_history_dirs(dirs):
     DebugPrint(2, "Number of alternate site name usage records: %d" % alternate_count)
     DebugPrint(2, "Number of usage records found: %d" % found_count)
     send_alternate_records(g_alternate_records)
+
+
+# process_history_file, except ValueError
+def process_history_file_eve(log):
+    try:
+        return process_history_file(log)
+    except ValueError as e:
+        DebugPrint(1, "Failed to parse log file: %s\nError was: %s" % (log, e))
+        return 0, 0, 0
+
 
 def process_history_file(logfile):
 

--- a/condor/condor_meter
+++ b/condor/condor_meter
@@ -353,7 +353,7 @@ def process_history_file(logfile):
     except IOError as ie:
         DebugPrint(2, "Cannot process %s: (errno=%d) %s" % (logfile, ie.errno,
             ie.strerror))
-        return 0, 0
+        return 0, 0, 0
     added_transient = False
 
     for classad in fd_to_classad(fd):


### PR DESCRIPTION
in particular, avoid accessing 'e' outside the except block where it is defined, which doesn't work in python3.

This is an alternative to #108, done instead as a refactor to remove (a bit of) the code smelled by @brianhlin.

Brian, feel free to let me know which of the two you like better.