### PR TITLE
create condor_meter.py symlink in test workflow

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -13,5 +13,8 @@ jobs:
     - name: install htcondor
       run: pip3 install htcondor pyopenssl
       
+    - name: symlink setup
+      run: ln -s condor_meter condor/condor_meter.py
+
     - name: run script
       run: python3 -m unittest discover --verbose --buffer  test

--- a/condor/condor_meter.py
+++ b/condor/condor_meter.py
@@ -1,1 +1,0 @@
-condor_meter


### PR DESCRIPTION
... rather than in the sources

the extra .py file caused .pyc files to be created, and none of these
were being packaged.  we could either rm it from the packaging, or drop
it from the sources and add it to the test workflow, which is what we
are doing here.