### PR TITLE
Update dCache-transfer probe and common2 lib for Python 3

### DIFF
--- a/common2/gratia/common2/checkpoint.py
+++ b/common2/gratia/common2/checkpoint.py
@@ -280,7 +280,7 @@ class DateTransactionCheckpoint(Checkpoint):
 
     def _load(self, target):
         pkl_file = open(target, 'rb')
-        self._dateStamp, self._transaction = pickle.load(pkl_file)
+        self._dateStamp, self._transaction = pickle.load(pkl_file,encoding='latin1')
         pkl_file.close()
 
     def get_val(self):
@@ -363,7 +363,7 @@ class DateTransactionCheckpoint(Checkpoint):
 
         if self._tmp_fp:
             self._tmp_fp.seek(0)
-            pickle.dump([datestamp, txn], self._tmp_fp, -1)
+            pickle.dump([datestamp, txn], self._tmp_fp, protocol=2)
             self._tmp_fp.truncate()
             self._tmp_fp.flush()
             # make sure that the file is on disk

--- a/common2/gratia/common2/checkpoint.py
+++ b/common2/gratia/common2/checkpoint.py
@@ -104,7 +104,7 @@ class Checkpoint(object):
         try:
             fd, fname = tempfile.mkstemp(suffix, prefix, dirname)
             # returning a file obj open for write instead of a file descriptor
-            return os.fdopen(fd, 'w'), fname
+            return os.fdopen(fd, 'wb'), fname
         except OSError:
             raise IOError("Could not open checkpoint file %sXXXX%s" % (os.path.join(dirname, prefix), suffix))
 

--- a/common2/gratia/common2/checkpoint.py
+++ b/common2/gratia/common2/checkpoint.py
@@ -476,7 +476,7 @@ class DateTransactionAuxCheckpoint(DateTransactionCheckpoint):
         # self._dateStamp, self._transaction, self._aux = cPickle.load(pkl_file)
         # Using a list instead of unpacking allows to upgrade from DateTransactionCheckpoint to
         # DateTransactionAuxCheckpoint
-        vlist = pickle.load(pkl_file)
+        vlist = pickle.load(pkl_file,encoding='latin1')
         self._dateStamp = vlist[0]
         self._transaction = vlist[1]
         if len(vlist) > 2:
@@ -525,7 +525,7 @@ class DateTransactionAuxCheckpoint(DateTransactionCheckpoint):
 
         if self._tmp_fp:
             self._tmp_fp.seek(0)
-            pickle.dump([datestamp, txn, aux], self._tmp_fp, -1)
+            pickle.dump([datestamp, txn, aux], self._tmp_fp, protocol=2)
             self._tmp_fp.truncate()
             self._tmp_fp.flush()
             # make sure that the file is on disk
@@ -626,7 +626,7 @@ def load_checkpoint(target):
     vlist = []
     try:
         pkl_file = open(target, 'rb')
-        vlist = pickle.load(pkl_file)
+        vlist = pickle.load(pkl_file,encoding='latin1')
     except IOError as e:
         (errno, strerror) = e.args
         print("Couldn't read the checkpoint file %s: %s." % (target, strerror))

--- a/common2/gratia/common2/meter.py
+++ b/common2/gratia/common2/meter.py
@@ -20,10 +20,6 @@ import optparse
 import signal  # is in the system library
 from .alarm import Alarm
 
-# Python profiler
-import hotshot
-import hotshot.stats
-
 # Gratia libraries
 import gratia.common.Gratia as Gratia
 #import gratia.services.ComputeElement as ComputeElement
@@ -467,11 +463,6 @@ class GratiaMeter(GratiaProbe):
             self._opts.test = self._check_test_values(self._opts.test)
         #TODO: check here start and end time?
 
-        # Enable profiling
-        if self._opts.profile:
-            self._main = self.main
-            self.main = self.do_profile
-
     def get_opts_parser(self):
         """Return an options parser. It must invoke the parent option parser.
 
@@ -506,8 +497,6 @@ Command line usage: %prog
         parser.add_option("--test", help="Comma separated list of probe components to test using stubs, "
             "e.g. input, output, all (=input,output).",
             dest="test", default="")
-        parser.add_option("--profile", help="Enable probe profiling ",
-            dest="profile", default=False, action="store_true")
         parser.add_option("-v", "--verbose",
             help="Enable verbose logging to stderr.",
             dest="verbose", default=False, action="store_true")
@@ -595,25 +584,6 @@ Command line usage: %prog
         # by default it is invoked only if --help is the first and only option
         # TODO: Trigger error for unsupported options?
         return parser.parse_args()
-
-    def do_profile(self):
-        """Wrap the main method in profiler execution
-        """
-        # Interesting use: http://code.activestate.com/recipes/576656-quick-python-profiling-with-hotshot/
-        # http://blog.brianbeck.com/post/22199891/the-state-of-python-profilers-in-two-words
-        # http://nose.readthedocs.org/en/latest/plugins/prof.html
-        # pass name, use in profiler file name, return profiling function
-        # TODO: provide a standard probe profiling
-
-        fname = "gratiaprobe_%s.prof" % self.probe_name
-        profiler = hotshot.Profile(fname)
-        DebugPrint(4, "Enabled profiling to %s" % fname)
-        retv = profiler.run("self._main()")
-        profiler.close()
-        stats = hotshot.stats.load(fname)
-        stats.sort_stats('time', 'calls')
-        stats.print_stats()
-        return retv
 
     def main(self):
         # Loop over completed jobs

--- a/dCache-storagegroup/dcache-storagegroup
+++ b/dCache-storagegroup/dcache-storagegroup
@@ -56,7 +56,7 @@ This reduces the load on the Gratia collector.""",
 
 def sendRecords(fn):
 
-    user_space=pickle.load(open(fn,"r"))
+    user_space=pickle.load(open(fn,"rb"),encoding='latin1')
     t = os.stat(fn).st_ctime
 
     storage_groups={}

--- a/dCache-transfer/gratia/dcache_transfer/Checkpoint.py
+++ b/dCache-transfer/gratia/dcache_transfer/Checkpoint.py
@@ -45,7 +45,10 @@ class Checkpoint:
 
         try:
             pklFile = open(tablename, 'rb')
-            self._dateStamp, self._transaction = pickle.load(pklFile)
+            # Using encoding='latin1' is required for unpickling NumPy arrays
+            # and instances of datetime, date and time pickled by Python 2.
+            # https://docs.python.org/3/library/pickle.html?highlight=pickle#pickle.Unpickler
+            self._dateStamp, self._transaction = pickle.load(pklFile,encoding='latin1')
             if self._dateStamp < minDay:
                 self._dateStamp = minDay
             ds = self._dateStamp
@@ -90,7 +93,7 @@ class Checkpoint:
         # Create new pending file.
         try:
             pklFile = open(self._tmpFile, 'wb')
-            pickle.dump([datestamp, txn], pklFile, -1)
+            pickle.dump([datestamp, txn], pklFile, protocol=2)
             pklFile.close()
             self._pending = True
             self._pending_dateStamp = datestamp

--- a/dCache-transfer/gratia/dcache_transfer/dCacheBillingAggregator.py
+++ b/dCache-transfer/gratia/dcache_transfer/dCacheBillingAggregator.py
@@ -16,9 +16,6 @@ import string
 import logging
 import traceback
 import xml.dom.minidom
-# Python profiler
-import hotshot
-import hotshot.stats
 
 from logging.handlers import RotatingFileHandler
 
@@ -228,12 +225,6 @@ def main():
         dataDir = myconf.get_DataFolder()
         aggregator = DCacheAggregator(myconf, dataDir)
 
-        # If profiling was requested, turn it on.
-        profiling = sys.argv.count('-profile') > 0
-        if profiling:
-            profiler = hotshot.Profile("profile.dat")
-            logger.info( "Enabling Profiling" )
-
         # Now aggregate new records, then sleep, until somebody creates
         # the stop file...
         while 1:
@@ -241,16 +232,13 @@ def main():
             if ( not TestContainer.isTest() ): # no need in that during self test
                Gratia.Maintenance()
           
-            if profiling:
-                profiler.run("aggregator.sendBillingInfoRecordsToGratia()")
-            else:
-                try:
-                    aggregator.sendBillingInfoRecordsToGratia()
-                except TestContainer.SimInterrupt:
-                    logger.info("BillingRecSimulator.SimInterrupt caught, " \
-                        "restarting")
-                    aggregator = DCacheAggregator(myconf, dataDir)
-                    continue
+            try:
+                aggregator.sendBillingInfoRecordsToGratia()
+            except TestContainer.SimInterrupt:
+                logger.info("BillingRecSimulator.SimInterrupt caught, " \
+                    "restarting")
+                aggregator = DCacheAggregator(myconf, dataDir)
+                continue
             # Are we are shutting down?
             if os.path.exists(stopFileName):
                 break
@@ -260,13 +248,6 @@ def main():
 
             logger.warn("sleeping for = %.2f seconds" % updateFreq)
             sleep_check(updateFreq, stopFileName)
-
-        # If we are profiling, print the results...
-        if profiling:
-            profiler.close()
-            stats = hotshot.stats.load("profile.dat")
-            stats.sort_stats('time', 'calls')
-            stats.print_stats()
 
         logger.warn(ProgramName + " stop file detected.")
     except (KeyboardInterrupt, SystemExit):

--- a/dCache-transfer/gratia/dcache_transfer/dCacheBillingAggregator.py
+++ b/dCache-transfer/gratia/dcache_transfer/dCacheBillingAggregator.py
@@ -12,7 +12,6 @@ import os
 import sys
 import time
 import signal
-import string
 import logging
 import traceback
 import xml.dom.minidom
@@ -103,7 +102,7 @@ class dCacheProbeConfig(ProbeConfiguration):
     # if using a local gratia repository.
     def get_OnlySendInterSiteTransfers( self ):
         result = self.getConfigAttribute( 'OnlySendInterSiteTransfers' );
-        return ((result == None) or (string.lower(result) == 'true'))
+        return ((result == None) or (result.lower() == 'true'))
 
     def get_MaxBillingHistoryDays( self ):
         default = 30

--- a/dCache-transfer/gratia/dcache_transfer/dCacheBillingAggregator.py
+++ b/dCache-transfer/gratia/dcache_transfer/dCacheBillingAggregator.py
@@ -102,7 +102,7 @@ class dCacheProbeConfig(ProbeConfiguration):
     # if using a local gratia repository.
     def get_OnlySendInterSiteTransfers( self ):
         result = self.getConfigAttribute( 'OnlySendInterSiteTransfers' );
-        return ((result == None) or (result.lower() == 'true'))
+        return result is None or result.lower() == 'true'
 
     def get_MaxBillingHistoryDays( self ):
         default = 30


### PR DESCRIPTION
The hotshot profiler was removed from from python 3, so I just stripped out the built-in profiling. If you want to profile a script now, you can just run `python -m cProfile myscript.py` (see https://docs.python.org/3/library/profile.html).

I'm still figuring out how to test this, since I don't have a test dCache environment or database. I may have to build a pre-release RPM (1.24.1-0.1?) and have our dCache admins do it live.