### PR TITLE
Drop OSPool specific configs (SOFTWARE-4846)

### DIFF
--- a/condor-ap/ProbeConfig.add
+++ b/condor-ap/ProbeConfig.add
@@ -5,11 +5,6 @@
 
     Lockfile="/var/lock/condor/gratia.lock"
 
-    SuppressGridLocalRecords="1"
-    MapUnknownToGroup="1"
-    MapGroupToRole="1"
-    VOOverride="OSG"
-
     CondorScheddName=""
       Comments91="Use this to set the name of the scheduler, if there are mutliple."
     NoCertinfoBatchRecordsAreLocal="0"

--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -523,6 +523,8 @@ The dCache storagegroup probe for the Gratia OSG accounting system.
 - Fix ownership of HTCondor AP directories (SOFTWARE-4846)
 - Fix case of Lockfile config name for HTCondor-CE and HTCondor AP
   probes (SOFTWARE-4621, SOFTWARE-4846)
+- Remove OSPool specific configuration in HTCondor AP ProbeConfig
+  (SOFTWARE-4846)
 
 * Wed Oct 06 2021 Carl Edquist <edquist@cs.wisc.edu> - 2.3.0-1
 - Consolidate condor and old glideinwms probe into condor-ap (SOFTWARE-4846)


### PR DESCRIPTION
This is a layering violation and we'll be moving this config to
osg-flock's %post