### PR TITLE
Drop superfluous DataFolder dir formatting check (SOFTWARE-4892)

### DIFF
--- a/condor-ap/ProbeConfig.add
+++ b/condor-ap/ProbeConfig.add
@@ -1,7 +1,7 @@
 
-    DataFolder="/var/lib/condor/gratia/data"
-    WorkingFolder="/var/lib/condor/gratia/tmp"
-    LogFolder="/var/log/condor/gratia"
+    DataFolder="/var/lib/condor/gratia/data/"
+    WorkingFolder="/var/lib/condor/gratia/tmp/"
+    LogFolder="/var/log/condor/gratia/"
 
     Lockfile="/var/lock/condor/gratia.lock"
 

--- a/condor-ap/condor_meter
+++ b/condor-ap/condor_meter
@@ -213,11 +213,6 @@ def main():
     if not htcondor_configured():
         DebugPrint(-1, "WARNING: HTCondor appears to not be configured correctly. Continuing anyway.")
 
-    # Do some sanity checks of gratia configuration before starting    
-    if not check_gratia():
-        DebugPrint(-1, "ERROR: Gratia settings not correct, exiting")
-        sys.exit(1)
-      
     if opts.condor_history is True:
         process_using_condor_history(opts.history_start_time, opts.history_end_time)
     else:
@@ -873,19 +868,6 @@ def htcondor_configured():
         DebugPrint(-1, "WARNING: Can't get information on PER_JOB_HISTORY_DIR, " \
                        "condor_config_val returned non-zero exit code")
     return False
-
-
-def check_gratia():
-    """
-    Make sure gratia configuration is somewhat sane before processing records
-    """
-    valid = True
-    data_folder = GratiaCore.Config.getConfigAttribute('DataFolder')
-    if data_folder[-1] != '/':
-        DebugPrint(-1, "ERROR: DataFolder must have a trailing / otherwise records "
-                       "will not be processed correctly")
-        valid = False
-    return valid
 
 
 def send_alternate_records(gratia_info):

--- a/htcondor-ce/ProbeConfig.add
+++ b/htcondor-ce/ProbeConfig.add
@@ -1,7 +1,7 @@
 
-    DataFolder="/var/lib/condor-ce/gratia/data"
-    WorkingFolder="/var/lib/condor-ce/gratia/tmp"
-    LogFolder="/var/log/condor-ce/gratia"
+    DataFolder="/var/lib/condor-ce/gratia/data/"
+    WorkingFolder="/var/lib/condor-ce/gratia/tmp/"
+    LogFolder="/var/log/condor-ce/gratia/"
 
     Lockfile="/var/lock/condor-ce/gratia.lock"
 


### PR DESCRIPTION
We use `os.path.samefile()` and `os.path.join()` whenever we handle
`DataFolder`, which robustly handle paths with or without the trailing slash

Also, add trailing slashes to dirs in the default configs just to be clearer that they're dirs.