### PR TITLE
Add SCHEDD_CRON_LOG_NON_ZERO_EXIT to htcondor-ce config (SOFTWARE-5150)

### DIFF
--- a/htcondor-ce/50-gratia-ce.conf
+++ b/htcondor-ce/50-gratia-ce.conf
@@ -16,5 +16,6 @@ SCHEDD_CRON_GRATIA_PREFIX = GRATIA
 SCHEDD_CRON_GRATIA_ARGS = -f /etc/gratia/htcondor-ce/ProbeConfig
 
 # log gratia probe failures to aid debugging
+# see HTCONDOR-971 for knob details
 SCHEDD_CRON_LOG_NON_ZERO_EXIT = True
 

--- a/htcondor-ce/50-gratia-ce.conf
+++ b/htcondor-ce/50-gratia-ce.conf
@@ -15,3 +15,6 @@ SCHEDD_CRON_GRATIA_EXECUTABLE = /usr/share/gratia/htcondor-ce/condor_meter
 SCHEDD_CRON_GRATIA_PREFIX = GRATIA
 SCHEDD_CRON_GRATIA_ARGS = -f /etc/gratia/htcondor-ce/ProbeConfig
 
+# log gratia probe failures to aid debugging
+SCHEDD_CRON_LOG_NON_ZERO_EXIT = True
+


### PR DESCRIPTION
This option was added in HTCONDOR-971. It's a no-op for older versions of HTCondor, but will help users debug failing gratia probes much more readily for supported versions.