### PR TITLE
downgrade certinfo errors/warnings to debug (SOFTWARE-4980)

### DIFF
--- a/common/gratia/common/certinfo.py
+++ b/common/gratia/common/certinfo.py
@@ -184,9 +184,9 @@ def readCertInfoLog(localJobId):
                     else:
                         res['FQAN'] = None
                     res['VO'] = None
-                    DebugPrint(0, 'Warning: found valid certinfo file for '+str(localJobId)+' in the log files: ' + pattern + ' with ' + str(res))
+                    # DebugPrint(0, 'Warning: found valid certinfo file for '+str(localJobId)+' in the log files: ' + pattern + ' with ' + str(res))
                     return res
-    DebugPrint(0, 'Warning: unable to find valid certinfo file for '+str(localJobId)+' in the log files: ' + pattern)
+    # DebugPrint(0, 'Warning: unable to find valid certinfo file for '+str(localJobId)+' in the log files: ' + pattern)
     return None
 
 # update this list as new job managers are added
@@ -249,7 +249,7 @@ def _findCertinfoFile(localJobId, probeName):
         except SystemExit:
             raise
         except Exception as e:
-            DebugPrint(0, 'ERROR: Unable to parse XML file ' + certinfo, ': ', e)
+            # DebugPrint(0, 'ERROR: Unable to parse XML file ' + certinfo, ': ', e)
             continue
 
         # Next, find the correct information and send it back.
@@ -277,11 +277,11 @@ def _findCertinfoFile(localJobId, probeName):
                 #file_utils.RemoveFile(certinfo)  # Clean up.
                 #break  # Done -- stop looking
         else:
-            DebugPrint(0, 'ERROR: certinfo file ' + certinfo + ' does not contain one single valid GratiaCertInfo node'
-                       )
+            # DebugPrint(0, 'ERROR: certinfo file ' + certinfo + ' does not contain one single valid GratiaCertInfo node')
+            pass
 
     # if here, no result found
-    DebugPrint(0, 'ERROR: unable to find valid certinfo file for job ' + localJobId)
+    # DebugPrint(0, 'ERROR: unable to find valid certinfo file for job ' + localJobId)
     return None
 
 def readCertInfoFile(localJobId, probeName):

--- a/common/gratia/common/certinfo.py
+++ b/common/gratia/common/certinfo.py
@@ -184,8 +184,10 @@ def readCertInfoLog(localJobId):
                     else:
                         res['FQAN'] = None
                     res['VO'] = None
+                    # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
                     # DebugPrint(0, 'Warning: found valid certinfo file for '+str(localJobId)+' in the log files: ' + pattern + ' with ' + str(res))
                     return res
+    # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
     # DebugPrint(0, 'Warning: unable to find valid certinfo file for '+str(localJobId)+' in the log files: ' + pattern)
     return None
 
@@ -249,6 +251,7 @@ def _findCertinfoFile(localJobId, probeName):
         except SystemExit:
             raise
         except Exception as e:
+            # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
             # DebugPrint(0, 'ERROR: Unable to parse XML file ' + certinfo, ': ', e)
             continue
 
@@ -277,10 +280,12 @@ def _findCertinfoFile(localJobId, probeName):
                 #file_utils.RemoveFile(certinfo)  # Clean up.
                 #break  # Done -- stop looking
         else:
+            # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
             # DebugPrint(0, 'ERROR: certinfo file ' + certinfo + ' does not contain one single valid GratiaCertInfo node')
             pass
 
     # if here, no result found
+    # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
     # DebugPrint(0, 'ERROR: unable to find valid certinfo file for job ' + localJobId)
     return None
 

--- a/common/gratia/common/condor_ce.py
+++ b/common/gratia/common/condor_ce.py
@@ -222,10 +222,10 @@ def createCertinfoFile(classad, directory):
             DebugPrint(4, "Unable write out certinfo file %s as it already " \
                 "exists." % full_filename)
             return True
-        DebugPrint(1, "Unable to write out certinfo file %s: %s " % \
-            (full_filename, str(oe)))
+        # DebugPrint(1, "Unable to write out certinfo file %s: %s " % \
+        #     (full_filename, str(oe)))
         return False
-    DebugPrint(3, "Successfully wrote certinfo file %s" % full_filename)
+    # DebugPrint(3, "Successfully wrote certinfo file %s" % full_filename)
     return True
 
 
@@ -242,15 +242,15 @@ def classadToCertinfo(filename, output_dir):
     try:
         fd = open(filename)
     except IOError as ie:
-        DebugPrint(1, "Unable to open ClassAd %s for certinfo conversion" \
-            ": %s" % (filename, str(ie)))
+        # DebugPrint(1, "Unable to open ClassAd %s for certinfo conversion" \
+        #     ": %s" % (filename, str(ie)))
         return
 
     for classad in fdToClassad(fd):
 
         if not createCertinfoFile(classad, output_dir):
-            DebugPrint(0, "Failed to convert certinfo file %s; sending to " \
-                "quarantine." % filename)
+            # DebugPrint(0, "Failed to convert certinfo file %s; sending to " \
+            #     "quarantine." % filename)
             sandbox_mgmt.QuarantineFile(filename, False)
             continue
 
@@ -267,8 +267,9 @@ def processHistoryDir():
     history_dir = Config.get_CondorCEHistoryFolder()
     output_dir = Config.get_DataFolder()
     if not history_dir:
-        DebugPrint(3, "No Condor-CE history specified; will not process for" \
-            " certinfo.")
+        # DebugPrint(3, "No Condor-CE history specified; will not process for" \
+        #     " certinfo.")
+        pass
     if not os.path.exists(history_dir):
         DebugPrint(3, "Condor-CE history directory %s does not exist." \
             % history_dir)
@@ -285,8 +286,8 @@ def processHistoryDir():
         except SystemExit:
             raise
         except Exception as e:
-            DebugPrint(0, "Failure when trying to process Condor-CE history %s" \
-                " into a certinfo file: %s" % (filename, str(e)))
+            # DebugPrint(0, "Failure when trying to process Condor-CE history %s" \
+            #     " into a certinfo file: %s" % (filename, str(e)))
             DebugPrintTraceback(e)
 
 
@@ -359,8 +360,8 @@ def queryJob(jobid):
         job_info = queryAllJobs()
         for classad in job_info.values():
             # On failure, there is not much to do - ignore
-            DebugPrint(3, "Creating certinfo file for %s." %
-                classad['GlobalJobId'])
+            # DebugPrint(3, "Creating certinfo file for %s." %
+            #     classad['GlobalJobId'])
             createCertinfoFile(classad, directory)
         _queryCache = job_info
     info = _queryCache.get(jobid, {})

--- a/common/gratia/common/condor_ce.py
+++ b/common/gratia/common/condor_ce.py
@@ -222,9 +222,11 @@ def createCertinfoFile(classad, directory):
             DebugPrint(4, "Unable write out certinfo file %s as it already " \
                 "exists." % full_filename)
             return True
+        # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
         # DebugPrint(1, "Unable to write out certinfo file %s: %s " % \
         #     (full_filename, str(oe)))
         return False
+    # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
     # DebugPrint(3, "Successfully wrote certinfo file %s" % full_filename)
     return True
 
@@ -242,6 +244,7 @@ def classadToCertinfo(filename, output_dir):
     try:
         fd = open(filename)
     except IOError as ie:
+        # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
         # DebugPrint(1, "Unable to open ClassAd %s for certinfo conversion" \
         #     ": %s" % (filename, str(ie)))
         return
@@ -249,6 +252,7 @@ def classadToCertinfo(filename, output_dir):
     for classad in fdToClassad(fd):
 
         if not createCertinfoFile(classad, output_dir):
+            # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
             # DebugPrint(0, "Failed to convert certinfo file %s; sending to " \
             #     "quarantine." % filename)
             sandbox_mgmt.QuarantineFile(filename, False)
@@ -267,6 +271,7 @@ def processHistoryDir():
     history_dir = Config.get_CondorCEHistoryFolder()
     output_dir = Config.get_DataFolder()
     if not history_dir:
+        # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
         # DebugPrint(3, "No Condor-CE history specified; will not process for" \
         #     " certinfo.")
         pass
@@ -286,6 +291,7 @@ def processHistoryDir():
         except SystemExit:
             raise
         except Exception as e:
+            # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
             # DebugPrint(0, "Failure when trying to process Condor-CE history %s" \
             #     " into a certinfo file: %s" % (filename, str(e)))
             DebugPrintTraceback(e)
@@ -359,6 +365,7 @@ def queryJob(jobid):
         directory = Config.get_DataFolder()
         job_info = queryAllJobs()
         for classad in job_info.values():
+            # XXX: certinfo is going away; no more warnings (SOFTWARE-4980)
             # On failure, there is not much to do - ignore
             # DebugPrint(3, "Creating certinfo file for %s." %
             #     classad['GlobalJobId'])


### PR DESCRIPTION
@brianhlin per discussion this morning as a first step for SOFTWARE-4980 we want to eliminate the certinfo error and warning messages.

I wasn't sure if it would be best to remove them entirely, so I've just downgraded them to debug-level messages.

Let me know if you'd like to handle this differently.