### PR TITLE
Replace AuthToken with routed job attrs (SOFTWARE-5185)

### DIFF
--- a/common/gratia/common/condor_ce.py
+++ b/common/gratia/common/condor_ce.py
@@ -304,8 +304,8 @@ condor_ce_q -const 'RoutedJob =?= true && GridJobId =!= UNDEFINED \
     -format 'x509UserProxyVOName=%s\t' x509UserProxyVOName \
     -format 'x509UserProxyFirstFQAN=%s\t' x509UserProxyFirstFQAN \
     -format 'x509userproxysubject=%s\t' x509userproxysubject \
-    -format 'AuthTokenIssuer=%s\t' AuthTokenIssuer \
-    -format 'AuthTokenSubject=%s\t' AuthTokenSubject \
+    -format 'AuthTokenIssuer=%s\t' orig_AuthTokenIssuer \
+    -format 'AuthTokenSubject=%s\t' orig_AuthTokenSubject \
     -format 'GridJobId=%s' GridJobId \
     -format '\n' junk \
 """

--- a/common/gratia/common/condor_ce.py
+++ b/common/gratia/common/condor_ce.py
@@ -143,19 +143,19 @@ def createCertinfoXML(classad):
 
     # Sample: x509UserProxyVOName = "cms"
     voStr = classad.get("x509UserProxyVOName", "") or \
-            classad.get("AuthTokenIssuer", "")
+            classad.get("orig_AuthTokenIssuer", "")
     vo = dom.createElement("VO")
     vo.appendChild(dom.createTextNode(voStr))
 
     # Sample: x509UserProxyFirstFQAN = "/cms/Role=NULL/Capability=NULL"
     fqanStr = classad.get("x509UserProxyFirstFQAN", "") or \
-              classad.get("AuthTokenIssuer", "")
+              classad.get("orig_AuthTokenIssuer", "")
     fqan = dom.createElement("FQAN")
     fqan.appendChild(dom.createTextNode(fqanStr))
 
     # Sample: x509userproxysubject = "/C=TW/O=AP/OU=GRID/CN=Nitish Dhingra 142746"
     dnStr = classad.get("x509userproxysubject", "") or \
-            classad.get("AuthTokenSubject", "")
+            classad.get("orig_AuthTokenSubject", "")
     dn = dom.createElement("DN")
     dn.appendChild(dom.createTextNode(dnStr))
 
@@ -304,8 +304,8 @@ condor_ce_q -const 'RoutedJob =?= true && GridJobId =!= UNDEFINED \
     -format 'x509UserProxyVOName=%s\t' x509UserProxyVOName \
     -format 'x509UserProxyFirstFQAN=%s\t' x509UserProxyFirstFQAN \
     -format 'x509userproxysubject=%s\t' x509userproxysubject \
-    -format 'AuthTokenIssuer=%s\t' orig_AuthTokenIssuer \
-    -format 'AuthTokenSubject=%s\t' orig_AuthTokenSubject \
+    -format 'orig_AuthTokenIssuer=%s\t' orig_AuthTokenIssuer \
+    -format 'orig_AuthTokenSubject=%s\t' orig_AuthTokenSubject \
     -format 'GridJobId=%s' GridJobId \
     -format '\n' junk \
 """
@@ -375,12 +375,12 @@ def queryJob(jobid):
     certinfo = {}
     if 'x509UserProxyVOName' in info:
         certinfo["VO"] = info['x509UserProxyVOName']
-    elif 'AuthTokenIssuer' in info:
-        certinfo["VO"] = info['AuthTokenIssuer']
+    elif 'orig_AuthTokenIssuer' in info:
+        certinfo["VO"] = info['orig_AuthTokenIssuer']
     if 'x509userproxysubject' in info:
         certinfo['DN'] = info['x509userproxysubject']
-    elif 'AuthTokenSubject' in info:
-        certinfo['DN'] = info['AuthTokenSubject']
+    elif 'orig_AuthTokenSubject' in info:
+        certinfo['DN'] = info['orig_AuthTokenSubject']
     if 'x509UserProxyFirstFQAN' in info:
         certinfo['FQAN'] = info['x509UserProxyFirstFQAN']
     # FQAN is used as a backup for DN/VO in the certinfo to populate

--- a/condor-ap/condor_meter
+++ b/condor-ap/condor_meter
@@ -590,15 +590,14 @@ def classadToJUR(classad):
 
     # a pre-routed job's AuthToken attrs are copied with "orig_" prefix
     # in the routed job (SOFTWARE-5185, HTCONDOR-1071)
-    ATpfx = "orig_" if probe_name == "htcondor-ce" else ""
     setIfExists(r.LocalUserId, classad, "Owner")
     setIfExists(r.GlobalUsername, classad, "User")
     setIfExists(r.DN, classad, 'x509userproxysubject') or \
-    setIfExists(r.DN, classad, ATpfx + 'AuthTokenSubject')
+    setIfExists(r.DN, classad, 'orig_AuthTokenSubject')
     setIfExists(r.VOName, classad, 'x509UserProxyFirstFQAN') or \
-    setIfExists(r.VOName, classad, ATpfx + 'AuthTokenIssuer')  # VO info for SciToken
+    setIfExists(r.VOName, classad, 'orig_AuthTokenIssuer')  # VO info for SciToken
     setIfExists(r.ReportableVOName, classad, 'x509UserProxyVOName') or \
-    setIfExists(r.ReportableVOName, classad, ATpfx + 'AuthTokenIssuer')
+    setIfExists(r.ReportableVOName, classad, 'orig_AuthTokenIssuer')
 
     if 'GlobalJobId' in classad:
         r.JobName(classad["GlobalJobId"])

--- a/condor-ap/condor_meter
+++ b/condor-ap/condor_meter
@@ -588,14 +588,17 @@ def classadToJUR(classad):
     # I don't think ProcessId was ever correct - used to take the UDP port 
     # from the LastClaimId?
 
+    # a pre-routed job's AuthToken attrs are copied with "orig_" prefix
+    # in the routed job (SOFTWARE-5185, HTCONDOR-1071)
+    ATpfx = "orig_" if probe_name == "htcondor-ce" else ""
     setIfExists(r.LocalUserId, classad, "Owner")
     setIfExists(r.GlobalUsername, classad, "User")
     setIfExists(r.DN, classad, 'x509userproxysubject') or \
-    setIfExists(r.DN, classad, 'AuthTokenSubject')
+    setIfExists(r.DN, classad, ATpfx + 'AuthTokenSubject')
     setIfExists(r.VOName, classad, 'x509UserProxyFirstFQAN') or \
-    setIfExists(r.VOName, classad, 'AuthTokenIssuer')  # VO info for SciToken
+    setIfExists(r.VOName, classad, ATpfx + 'AuthTokenIssuer')  # VO info for SciToken
     setIfExists(r.ReportableVOName, classad, 'x509UserProxyVOName') or \
-    setIfExists(r.ReportableVOName, classad, 'AuthTokenIssuer')
+    setIfExists(r.ReportableVOName, classad, ATpfx + 'AuthTokenIssuer')
 
     if 'GlobalJobId' in classad:
         r.JobName(classad["GlobalJobId"])


### PR DESCRIPTION
Per SOFTWARE-5185, the AuthToken* attributes we used for VO info in the
htcondor-ce probe don't exist in the routed job for non-condor batch
systems.  And, even worse, these may have entirely different values for
condor batch systems (a different token can be used to authN to the local
schedd).

In HTCONDOR-1071, htcondor-ce config is added to copy the pre-routed
job's AuthToken* attrs to orig_AuthToken* attrs in the routed job.

Thus, SOFTWARE-5185 calls for replacing the AuthToken* references in the
htcondor-ce probe with orig_AuthToken*.  In order to make this
probe-specific, I add a probe_name check, as the condor-ap and
htcondor-ce probes share the same probe code.

Note also that AuthToken* references exist in common/condor_ce.py,
in certinfo code (which seems to be unimportant at this point, since
it's going away), but also in CheckAndExtendUserIdentity from
common/xml_utils.py, to fill in missing vo info for jobs by querying the
htcondor-ce directly.  Do these need to get the "orig_" prefix also?
(Always? Just when running the htcondor-ce probe?  Never?)

...

It _seems_ to me that for the condor_ce.py code we just need to update the attr names in the condor_ce_q query, which is made against routed jobs - and that being the case i always query the `orig_`-prefixed names (not just in the htcondor-ce probe case).