### PR TITLE
fix wrongful tuple concatenation (SOFTWARE-5199)

### DIFF
--- a/common/gratia/common/send.py
+++ b/common/gratia/common/send.py
@@ -172,11 +172,11 @@ def Send(record):
                     match = re.search(r'^<(?:[^:]*:)?RecordIdentity.*/>$', usageXmlString, re.MULTILINE)
                     if match:
                         DebugPrint(0, match.group(0))
-                        responseString += ('\n', match.group(0))
+                        responseString += '\n' + match.group(0)
                     match = re.search(r'^<(?:[^:]*:)?GlobalJobId.*/>$', usageXmlString, re.MULTILINE)
                     if match:
                         DebugPrint(0, match.group(0))
-                        responseString += ('\n', match.group(0))
+                        responseString += '\n' + match.group(0)
                     responseString += '\n' + usageXmlString
                 else:
                     DebugPrint(1, 'Response indicates failure, ' + f.name + ' will not be deleted')


### PR DESCRIPTION
responseString is a str, never made sense to add a tuple to it.

this dates back over 15 years, to 17d8465b, where presumably a comma was accidentally used instead of a plus.  apparently it didn't get seen much, as it only gets tripped on send failure.