### PR TITLE
Fix condor-ap probe bug(s) in resource name detection (SOFTWARE-5285)

### DIFF
--- a/condor-ap/condor_meter
+++ b/condor-ap/condor_meter
@@ -508,8 +508,9 @@ def cream_match(match, desired):
 
 def get_classad_resource_name(classad):
     for attr in RESOURCE_NAME_ATTRS:
-        if attr in classad:
-            return classad[attr]
+        resource_name = classad.get(attr)
+        if resource_name:
+            return resource_name
     return None
 
 

--- a/condor-ap/condor_meter
+++ b/condor-ap/condor_meter
@@ -533,7 +533,7 @@ def determine_host_description(classad):
     elif resource_name == 'Local Job':
         host_descr = GratiaCore.Config.get_SiteName()
     else:
-        host_descr = classad[attr]
+        host_descr = resource_name
 
     # Check first for SE-based matching.
     if ('DESIRED_SEs' not in classad) or ('MATCH_GLIDEIN_SEs' not in classad):


### PR DESCRIPTION
regarding the fix in `get_classad_resource_name()`, David Schultz reported in icecube-condor:

> we have at least one site where the first value is undefined while the second is correct. those are getting put into quarantine right now. maybe there should be a check that the attr is valid?

...

And the second bit that had `host_descr = classad[attr]` sadly was just broken. Incomplete refactoring when i broke out `get_classad_resource_name()` into a separate function.