### PR TITLE
Log and bail when there are dir creation issues (SOFTWARE-5531)

### DIFF
--- a/common/gratia/common/debug.py
+++ b/common/gratia/common/debug.py
@@ -7,7 +7,7 @@ import time
 import syslog
 import traceback
 
-from gratia.common.file_utils import Mkdir
+from gratia.common.utils import InternalError
 
 __logFileIsWriteable__ = True
 __quiet__ = 0
@@ -95,8 +95,11 @@ def LogToFile(message):
 
         # Ensure the 'logs' folder exists
 
-        if os.path.exists(getGratiaConfig().get_LogFolder()) == 0:
-            Mkdir(getGratiaConfig().get_LogFolder())
+        log_dir = getGratiaConfig().get_LogFolder()
+        try:
+            os.makedirs(getGratiaConfig().get_LogFolder(), exist_ok=True)
+        except OSError as exc:
+            raise InternalError(f'ERROR: failed to create log directory: {log_dir}') from exc
 
         filename = LogFileName()
 

--- a/common/gratia/common/file_utils.py
+++ b/common/gratia/common/file_utils.py
@@ -6,39 +6,6 @@ from gratia.common.config import ConfigProxy
 
 Config = ConfigProxy()
 
-##
-## Mkdir
-##
-## Author - Trent Mick (other recipes)
-##
-## A more friendly mkdir() than Python's standard os.mkdir().
-## Limitations: it doesn't take the optional 'mode' argument
-## yet.
-##      
-## http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/82465
-def Mkdir(newdir):
-    """works the way a good mkdir should :)
-        - already exists, silently complete
-        - regular file in the way, raise an exception
-        - parent directory(ies) does not exist, make them as well
-    """
-        
-    if os.path.isdir(newdir):
-        pass
-    elif os.path.isfile(newdir):
-        raise OSError("a file with the same name as the desired dir, '%s', already exists." % newdir)
-    else:   
-        (head, tail) = os.path.split(newdir)
-        if head and not os.path.isdir(head):
-            Mkdir(head)
-
-        # Mkdir can not use DebugPrint since it is used
-        # while trying to create the log file!
-        # print "Mkdir %s" % repr(newdir)
-
-        if tail:
-            os.mkdir(newdir)
-
 
 def RemoveFile(filename):
 

--- a/common/gratia/common/probe_config.py
+++ b/common/gratia/common/probe_config.py
@@ -16,7 +16,6 @@ import gratia.common.connect_utils as connect_utils
 import gratia.common.utils as utils
 import gratia.common.bundle as bundle
 
-from gratia.common.file_utils import Mkdir
 from gratia.common.debug import DebugPrint, DebugPrintTraceback
 
 __certrequestRejected__ = False
@@ -162,11 +161,22 @@ class ProbeConfiguration:
             # First create any sub-directory if needed.
 
             keydir = os.path.dirname(keyfile)
-            if keydir != r'' and os.path.exists(keydir) == 0:
-                Mkdir(keydir)
+            if keydir:
+                try:
+                    os.makedirs(keydir, exist_ok=True)
+                except OSError as exc:
+                    msg = f'ERROR: failed to create key directory: {keydir}'
+                    DebugPrint(0, msg + ':' + exc)
+                    raise utils.InternalError(msg) from exc
+
             certdir = os.path.dirname(certfile)
-            if certdir != r'' and os.path.exists(certdir) == 0:
-                Mkdir(certdir)
+            if certdir:
+                try:
+                    os.makedirs(certdir, exist_ok=True)
+                except OSError as exc:
+                    msg = f'ERROR: failed to create certificate directory: {certdir}'
+                    DebugPrint(0, msg + ':' + exc)
+                    raise utils.InternalError(msg) from exc
 
             # and then save the pem files
 

--- a/common/gratia/common/record.py
+++ b/common/gratia/common/record.py
@@ -6,7 +6,7 @@ import gratia.common.config as config
 import gratia.common.utils as utils
 import gratia.common.xml_utils as xml_utils
 
-from gratia.common.file_utils import Mkdir, RemoveFile
+from gratia.common.file_utils import RemoveFile
 from gratia.common.debug import DebugPrint
 
 Config = config.ConfigProxy()
@@ -184,7 +184,13 @@ class Record(object):
         ''' Copy to a quarantine directories any of the input files '''
         
         quarantinedir = os.path.join(Config.get_DataFolder(),"quarantine")
-        Mkdir(quarantinedir)
+        try:
+            os.makedirs(quarantinedir, exist_ok=True)
+        except OSError as exc:
+            msg = f'ERROR: Failed to create quarantine directory: {quarantinedir}'
+            DebugPrint(0, msg + ':' + exc)
+            raise utils.InternalError(msg) from exc
+
         for filename in self.TransientInputFiles:
             DebugPrint(1, 'Moving transient input file: '+filename+' to quarantine in '+quarantinedir)
             shutil.copy2(filename,quarantinedir)

--- a/common/gratia/common/sandbox_mgmt.py
+++ b/common/gratia/common/sandbox_mgmt.py
@@ -569,8 +569,8 @@ def OpenNewRecordFile(dirIndex):
             if not os.path.exists(working_dir):
                 try:
                     Mkdir(working_dir)
-                except Exception as e:
-                    DebugPrint(0, 'Warning: Exception caught while creating directory: ' + working_dir + ':' + e)
+                except Exception as exc:
+                    DebugPrint(0, 'Warning: Exception caught while creating directory: ' + working_dir + ':' + exc)
                     continue
             if not os.path.exists(working_dir):
                 DebugPrint(0, 'Warning: Directory does not exist even after attempting a Mkdir: ' + working_dir)

--- a/common/gratia/common/sandbox_mgmt.py
+++ b/common/gratia/common/sandbox_mgmt.py
@@ -8,7 +8,7 @@ import shutil
 import tarfile
 
 from gratia.common.config import ConfigProxy
-from gratia.common.file_utils import Mkdir, RemoveFile
+from gratia.common.file_utils import RemoveFile
 from gratia.common.utils import niceNum, InternalError
 from gratia.common.debug import DebugPrint, DebugPrintTraceback, LogFileName
 import gratia.common.global_state as global_state
@@ -39,7 +39,14 @@ def QuarantineFile(filename, isempty):
         else:
             toppath = pardirname
     quarantine = os.path.join(toppath, 'quarantine')
-    Mkdir(quarantine)
+
+    try:
+        os.makedirs(quarantine, exist_ok=True)
+    except OSError as exc:
+        msg = f'ERROR: Failed to create quarantine directory: {quarantine}'
+        DebugPrint(0, msg + ':' + exc)
+        raise InternalError(msg) from exc
+
     DebugPrint(0, 'Putting a quarantine file in: ' + quarantine)
     DebugPrint(3, 'Putting a file in quarantine: ' + os.path.basename(filename))
     if isempty:
@@ -243,7 +250,13 @@ def DirListAdd(value):
 def InitDirList():
     '''Initialize the list of backup directories'''
 
-    Mkdir(Config.get_WorkingFolder())
+    working_dir = Config.get_WorkingFolder()
+    try:
+        os.makedirs(working_dir, exist_ok=True)
+    except OSError as exc:
+        msg = f'ERROR: Failed to create working directory: {working_dir}'
+        DebugPrint(0, msg + ':' + exc)
+        raise InternalError(msg) from exc
 
     DirListAdd(Config.get_WorkingFolder())
     DebugPrint(1, 'List of backup directories: ', backupDirList)
@@ -369,7 +382,14 @@ def SearchOutstandingRecord():
             if UncompressOutbox(stagedfile, stagedoutbox):
                 RemoveFile(stagedfile)
             else:
-                Mkdir(os.path.join(staged, 'quarantine'))
+                quarantine_dir = os.path.join(staged, 'quarantine')
+                try:
+                    os.makedirs(quarantine_dir, exist_ok=True)
+                except OSError as exc:
+                    msg = f'ERROR: Failed to create quarantine directory: {quarantine_dir}'
+                    DebugPrint(0, msg + ':' + exc)
+                    raise InternalError(msg) from exc
+
                 os.rename(stagedfile, os.path.join(staged, 'quarantine', os.path.basename(stagedfile)))
 
             outstandingStagedTarCount += -1
@@ -460,7 +480,12 @@ def CompressOutbox(probe_dir, outbox, outfiles):
     global outstandingStagedTarCount
 
     staged_store = os.path.join(probe_dir, 'staged', 'store')
-    Mkdir(staged_store)
+    try:
+        os.makedirs(staged_store, exist_ok=True)
+    except OSError as exc:
+        msg = f'ERROR: Failed to create staged directory: {staged_store}'
+        DebugPrint(0, msg + ':' + exc)
+        raise InternalError(msg) from exc
 
     staging_name = GenerateFilename('tz.', staged_store)
     DebugPrint(1, 'Compressing outbox in tar.bz2 file: ' + staging_name)
@@ -567,8 +592,8 @@ def OpenNewRecordFile(dirIndex):
                     continue
 
             try:
-                Mkdir(working_dir)
-            except Exception as exc:
+                os.makedirs(working_dir, exist_ok=True)
+            except OSError as exc:
                 msg = 'ERROR: Exception caught while creating directory: ' + working_dir
                 DebugPrint(0, msg + ':' + exc)
                 raise InternalError(msg) from exc

--- a/common/gratia/common/sandbox_mgmt.py
+++ b/common/gratia/common/sandbox_mgmt.py
@@ -587,7 +587,6 @@ def OpenNewRecordFile(dirIndex):
                 return (f, dirIndex)
             except Exception as exc:
                 DebugPrint(0, 'Caught exception while creating file: ', exc)
-                DebugPrintTraceback()
                 continue
     else:
         DebugPrint(0, 'DEBUG: Too many pending files, the record has not been backed up')

--- a/common/gratia/common/sandbox_mgmt.py
+++ b/common/gratia/common/sandbox_mgmt.py
@@ -566,21 +566,13 @@ def OpenNewRecordFile(dirIndex):
 
                     continue
 
-            if not os.path.exists(working_dir):
-                try:
-                    Mkdir(working_dir)
-                except Exception as exc:
-                    msg = 'ERROR: Exception caught while creating directory: ' + working_dir
-                    DebugPrint(0, msg + ':' + exc)
-                    raise InternalError(msg) from exc
-            if not os.path.exists(working_dir):
-                msg = 'ERROR: Directory does not exist even after attempting a Mkdir: ' + working_dir
-                DebugPrint(0, msg)
-                raise InternalError(msg)
-            if not os.access(working_dir, os.W_OK):
-                msg = 'ERROR: Directory is not writable: ' + working_dir
-                DebugPrint(0, msg)
-                raise InternalError(msg)
+            try:
+                Mkdir(working_dir)
+            except Exception as exc:
+                msg = 'ERROR: Exception caught while creating directory: ' + working_dir
+                DebugPrint(0, msg + ':' + exc)
+                raise InternalError(msg) from exc
+
             try:
                 filename = GenerateFilename('r.', working_dir)
                 DebugPrint(3, 'Creating file:', filename)

--- a/common/gratia/common/sandbox_mgmt.py
+++ b/common/gratia/common/sandbox_mgmt.py
@@ -569,11 +569,14 @@ def OpenNewRecordFile(dirIndex):
             if not os.path.exists(working_dir):
                 try:
                     Mkdir(working_dir)
-                except:
+                except Exception as e:
+                    DebugPrint(0, 'Warning: Exception caught while creating directory: ' + working_dir + ':' + e)
                     continue
             if not os.path.exists(working_dir):
+                DebugPrint(0, 'Warning: Directory does not exist even after attempting a Mkdir: ' + working_dir)
                 continue
             if not os.access(working_dir, os.W_OK):
+                DebugPrint(0, 'Warning: Directory is not writable: ' + working_dir)
                 continue
             try:
                 filename = GenerateFilename('r.', working_dir)
@@ -582,7 +585,9 @@ def OpenNewRecordFile(dirIndex):
                 f = open(filename, 'w')
                 dirIndex = index
                 return (f, dirIndex)
-            except:
+            except Exception as e:
+                DebugPrint(0, 'Caught exception while creating file: ', e)
+                DebugPrintTraceback()
                 continue
     else:
         DebugPrint(0, 'DEBUG: Too many pending files, the record has not been backed up')

--- a/common/gratia/common/sandbox_mgmt.py
+++ b/common/gratia/common/sandbox_mgmt.py
@@ -9,7 +9,7 @@ import tarfile
 
 from gratia.common.config import ConfigProxy
 from gratia.common.file_utils import Mkdir, RemoveFile
-from gratia.common.utils import niceNum
+from gratia.common.utils import niceNum, InternalError
 from gratia.common.debug import DebugPrint, DebugPrintTraceback, LogFileName
 import gratia.common.global_state as global_state
 
@@ -570,14 +570,17 @@ def OpenNewRecordFile(dirIndex):
                 try:
                     Mkdir(working_dir)
                 except Exception as exc:
-                    DebugPrint(0, 'Warning: Exception caught while creating directory: ' + working_dir + ':' + exc)
-                    continue
+                    msg = 'Warning: Exception caught while creating directory: ' + working_dir
+                    DebugPrint(0, msg + ':' + exc)
+                    raise InternalError(msg) from exc
             if not os.path.exists(working_dir):
-                DebugPrint(0, 'Warning: Directory does not exist even after attempting a Mkdir: ' + working_dir)
-                continue
+                msg = 'Warning: Directory does not exist even after attempting a Mkdir: ' + working_dir
+                DebugPrint(0, msg)
+                raise InternalError(msg)
             if not os.access(working_dir, os.W_OK):
-                DebugPrint(0, 'Warning: Directory is not writable: ' + working_dir)
-                continue
+                msg = 'Warning: Directory is not writable: ' + working_dir
+                DebugPrint(0, msg)
+                raise InternalError(msg)
             try:
                 filename = GenerateFilename('r.', working_dir)
                 DebugPrint(3, 'Creating file:', filename)
@@ -586,8 +589,9 @@ def OpenNewRecordFile(dirIndex):
                 dirIndex = index
                 return (f, dirIndex)
             except Exception as exc:
-                DebugPrint(0, 'Caught exception while creating file: ', exc)
-                continue
+                msg = 'Caught exception while creating file'
+                DebugPrint(0, msg + ': ', exc)
+                raise InternalError(msg + '. See logs for additional details') from exc
     else:
         DebugPrint(0, 'DEBUG: Too many pending files, the record has not been backed up')
     f = sys.stdout

--- a/common/gratia/common/sandbox_mgmt.py
+++ b/common/gratia/common/sandbox_mgmt.py
@@ -585,8 +585,8 @@ def OpenNewRecordFile(dirIndex):
                 f = open(filename, 'w')
                 dirIndex = index
                 return (f, dirIndex)
-            except Exception as e:
-                DebugPrint(0, 'Caught exception while creating file: ', e)
+            except Exception as exc:
+                DebugPrint(0, 'Caught exception while creating file: ', exc)
                 DebugPrintTraceback()
                 continue
     else:

--- a/common/gratia/common/sandbox_mgmt.py
+++ b/common/gratia/common/sandbox_mgmt.py
@@ -570,15 +570,15 @@ def OpenNewRecordFile(dirIndex):
                 try:
                     Mkdir(working_dir)
                 except Exception as exc:
-                    msg = 'Warning: Exception caught while creating directory: ' + working_dir
+                    msg = 'ERROR: Exception caught while creating directory: ' + working_dir
                     DebugPrint(0, msg + ':' + exc)
                     raise InternalError(msg) from exc
             if not os.path.exists(working_dir):
-                msg = 'Warning: Directory does not exist even after attempting a Mkdir: ' + working_dir
+                msg = 'ERROR: Directory does not exist even after attempting a Mkdir: ' + working_dir
                 DebugPrint(0, msg)
                 raise InternalError(msg)
             if not os.access(working_dir, os.W_OK):
-                msg = 'Warning: Directory is not writable: ' + working_dir
+                msg = 'ERROR: Directory is not writable: ' + working_dir
                 DebugPrint(0, msg)
                 raise InternalError(msg)
             try:
@@ -589,7 +589,7 @@ def OpenNewRecordFile(dirIndex):
                 dirIndex = index
                 return (f, dirIndex)
             except Exception as exc:
-                msg = 'Caught exception while creating file'
+                msg = 'ERROR: Caught exception while creating file'
                 DebugPrint(0, msg + ': ', exc)
                 raise InternalError(msg + '. See logs for additional details') from exc
     else:


### PR DESCRIPTION
Includes #169 . I've opted to just go with the exception route -- there aren't that many call sites:

1. https://github.com/opensciencegrid/gratia-probe/blob/2.x/common/gratia/common/send.py#L305-L305
2. https://github.com/opensciencegrid/gratia-probe/blob/2.x/common/gratia/common/send.py#L91-L91

But `Send` has quite a bit of call sites so I think I prefer just bailing loudly with an exception in this case because if the working dir isn't writeable then there's going to be a lot of trouble.