### PR TITLE
Refactor tempfile creation (SOFTWARE-5531)

### DIFF
--- a/common/gratia/common/sandbox_mgmt.py
+++ b/common/gratia/common/sandbox_mgmt.py
@@ -478,20 +478,21 @@ def CompressOutbox(probe_dir, outbox, outfiles):
         DebugPrint(0, msg + ':' + exc)
         raise InternalError(msg) from exc
 
-    staging_name = GenerateFilename('tz.', staged_store)
-    DebugPrint(1, 'Compressing outbox in tar.bz2 file: ' + staging_name)
+    with GenerateFilename('tz', staged_store) as temp_tarfile:
+        staging_name = temp_tarfile.name
+        DebugPrint(1, 'Compressing outbox in tar.bz2 file: ' + staging_name)
 
-    try:
-        tar = tarfile.open(staging_name, 'w:bz2')
-    except KeyboardInterrupt:
-        raise   
-    except SystemExit:
-        raise   
-    except Exception as e:
-        DebugPrint(0, 'Warning: Exception caught while opening tar.bz2 file: ' + staging_name + ':')
-        DebugPrint(0, 'Caught exception: ', e)
-        DebugPrintTraceback()
-        return False
+        try:
+            tar = tarfile.open(staging_name, 'w:bz2')
+        except KeyboardInterrupt:
+            raise
+        except SystemExit:
+            raise
+        except Exception as e:
+            DebugPrint(0, 'Warning: Exception caught while opening tar.bz2 file: ' + staging_name + ':')
+            DebugPrint(0, 'Caught exception: ', e)
+            DebugPrintTraceback()
+            return False
 
     try:
         for f in outfiles:

--- a/common/gratia/common/xml_utils.py
+++ b/common/gratia/common/xml_utils.py
@@ -280,10 +280,8 @@ def UsageCheckXmldoc(xmlDoc, external, resourceType=None):
                 subdir = os.path.join(Config.get_DataFolder(), "quarantine", 'subdir.' + Config.getFilenameFragment())
                 if not os.path.exists(subdir):
                     os.mkdir(subdir)
-                fn = sandbox_mgmt.GenerateFilename("r.", subdir)
-                writer = open(fn, 'w')
-                usageRecord.writexml(writer)
-                writer.close()
+                with sandbox_mgmt.GenerateFilename("r", subdir) as writer:
+                    usageRecord.writexml(writer)
             usageRecord.unlink()
             continue
 

--- a/test/test_sandbox_mgmt.py
+++ b/test/test_sandbox_mgmt.py
@@ -12,22 +12,23 @@ class SandboxMgmtTests(unittest.TestCase):
     def test_GenerateFilename(self, mock_config):
         """GenerateFilename creates a temporary file and returns the path to the file
         """
-        prefix = 'test-prefix.'
+        prefix = 'test-prefix'
         temp_dir = '/tmp'
 
         try:
-            filename = sandbox_mgmt.GenerateFilename(prefix, temp_dir)
-            self.assertTrue(os.path.exists(filename),
-                            f'Failed to create temporary file ({filename})')
-            self.assertEqual(temp_dir.rstrip('/'),
-                             os.path.dirname(filename),
-                             f'Temporary file {filename} placed in the wrong directory')
-            self.assertRegex(filename,
-                             rf'{temp_dir}/*{prefix}\d+\.{mock_config.return_value}__\w+',
-                             'Unexpected file name format')
+            with sandbox_mgmt.GenerateFilename(prefix, temp_dir) as filename:
+                self.assertTrue(os.path.exists(filename.name),
+                                f'Failed to create temporary file ({filename.name})')
+                self.assertEqual(temp_dir.rstrip('/'),
+                                 os.path.dirname(filename.name),
+                                 f'Temporary file {filename.name} placed in the wrong directory')
+                self.assertRegex(filename.name,
+                                 rf'{temp_dir}/*{prefix}\.\d+\.{mock_config.return_value}__\w+',
+                                 'Unexpected file name format')
         finally:
             try:
-                os.remove(filename)
-            except FileNotFoundError:
+                filename.close()
+                os.remove(filename.name)
+            except (FileNotFoundError, NameError):
                 # don't need to clean up what's not there
                 pass

--- a/test/test_sandbox_mgmt.py
+++ b/test/test_sandbox_mgmt.py
@@ -1,0 +1,33 @@
+#!/bin/env python
+
+import os
+import unittest
+from unittest.mock import patch, PropertyMock
+
+from common.gratia.common import sandbox_mgmt
+
+class SandboxMgmtTests(unittest.TestCase):
+
+    @patch('gratia.common.config.ConfigProxy.get_GratiaExtension', create=True, return_value='test-extension')
+    def test_GenerateFilename(self, mock_config):
+        """GenerateFilename creates a temporary file and returns the path to the file
+        """
+        prefix = 'test-prefix.'
+        temp_dir = '/tmp'
+
+        try:
+            filename = sandbox_mgmt.GenerateFilename(prefix, temp_dir)
+            self.assertTrue(os.path.exists(filename),
+                            f'Failed to create temporary file ({filename})')
+            self.assertEqual(temp_dir.rstrip('/'),
+                             os.path.dirname(filename),
+                             f'Temporary file {filename} placed in the wrong directory')
+            self.assertRegex(filename,
+                             rf'{temp_dir}/*{prefix}\d+\.{mock_config.return_value}__\w+',
+                             'Unexpected file name format')
+        finally:
+            try:
+                os.remove(filename)
+            except FileNotFoundError:
+                # don't need to clean up what's not there
+                pass


### PR DESCRIPTION
This changes `GenerateFilename` to use the `tempfile` library, making it return a `_TemporaryFileWrapper` (file-like interface), and fixes the `prefix` arg to work as documented (i.e., callers don't need to add the trailing `.`)

Marked as WIP because 1) the tar bits are unfinished, 2) needs some actual testing, and 3) would be nice to finally add some type hints.