### PR TITLE
Kuantifier Release Candidate Bugfixes

### DIFF
--- a/kubernetes/gratia_k8s_config.py
+++ b/kubernetes/gratia_k8s_config.py
@@ -27,3 +27,15 @@ class GratiaK8sConfig:
         self.gratia_config_path = env.str("GRATIA_CONFIG_PATH", "/etc/gratia/kubernetes/")
 
         self.gratia_probe_version = env.str("GRATIA_PROBE_VERSION", None)
+
+
+    def __str__(self) -> str:
+        return f"""
+OUTPUT_PATH={self.output_path}
+INFRASTRUCTURE_TYPE={self.infrastructure_type}
+INFRASTRUCTURE_DESC={self.infrastructure_description}
+NODECOUNT={self.nodecount}
+PROCESSORS={self.processors}
+GRATIA_CONFIG_PATH={self.gratia_config_path}
+GRATIA_PROBE_VERSION={self.gratia_probe_version}
+"""

--- a/kubernetes/kubernetes_meter.py
+++ b/kubernetes/kubernetes_meter.py
@@ -44,9 +44,10 @@ class ApelRecordConverter():
         self.apel_dict = {}
         lines = apel_record.split('\n')
         for line in lines:
-            kv_pair = [v.strip() for v in line.split(':')]
-            if len(kv_pair) == 2:
-                self.apel_dict[kv_pair[0]] = kv_pair[1]
+            # Handle case where apel values contain colons (eg. 'SubmitHost: http://localhost:8000')
+            kv_pair_match = re.match(r'([A-Za-z0-9_]+)\s*:\s*([^\s].*[^\s])\s*',line)
+            if kv_pair_match:
+                self.apel_dict[kv_pair_match[1]] = kv_pair_match[2]
 
     def getint(self, key):
         return int(float(self.apel_dict.get(key, 0)))

--- a/kubernetes/kubernetes_meter.py
+++ b/kubernetes/kubernetes_meter.py
@@ -4,6 +4,7 @@ import datetime
 from gratia_k8s_config import GratiaK8sConfig
 from dirq.QueueSimple import QueueSimple
 import os
+from math import ceil
 from datetime import datetime, timezone 
 import re
 
@@ -44,16 +45,15 @@ class ApelRecordConverter():
         self.apel_dict = {}
         lines = apel_record.split('\n')
         for line in lines:
-            # Handle case where apel values contain colons (eg. 'SubmitHost: http://localhost:8000')
-            kv_pair_match = re.match(r'([A-Za-z0-9_]+)\s*:\s*([^\s].*[^\s])\s*',line)
-            if kv_pair_match:
-                self.apel_dict[kv_pair_match[1]] = kv_pair_match[2]
+            kv_pair = [v.strip() for v in line.split(':', maxsplit=1)]
+            if len(kv_pair) == 2:
+                self.apel_dict[kv_pair[0]] = kv_pair[1]
 
     def getint(self, key):
         return int(float(self.apel_dict.get(key, 0)))
 
     def getint_roundup(self, key):
-        return int(float(self.apel_dict.get(key, 0)) + 0.5)
+        return ceil(float(self.apel_dict.get(key, 0)))
 
     def get(self, key):
         return self.apel_dict.get(key)

--- a/kubernetes/kubernetes_meter.py
+++ b/kubernetes/kubernetes_meter.py
@@ -151,10 +151,9 @@ def batch_dirq(queue, batch_size):
 
 def main(envFile: str):
     print(f'Starting Gratia post-processor: {__file__} with envFile {envFile} at {datetime.now(tz=timezone.utc).isoformat()}')
-    with open(envFile) as envf:
-        print(f'===== envFile contents: =====\n{envf.read()}')
 
     cfg = GratiaK8sConfig(envFile)
+    print(f'===== Gratia K8s Config: =====\n{str(cfg)}')
 
     setup_gratia(cfg)
 

--- a/kubernetes/kubernetes_meter.py
+++ b/kubernetes/kubernetes_meter.py
@@ -52,6 +52,9 @@ class ApelRecordConverter():
     def getint(self, key):
         return int(float(self.apel_dict.get(key, 0)))
 
+    def getint_roundup(self, key):
+        return int(float(self.apel_dict.get(key, 0)) + 0.5)
+
     def get(self, key):
         return self.apel_dict.get(key)
     
@@ -78,7 +81,7 @@ class ApelRecordConverter():
         r.WallDuration(self.getint('WallDuration'), SECONDS)
         r.CpuDuration( self.getint('CpuDuration'), USER, SECONDS)
         r.Memory(      self.getint('MemoryVirtual'), 'KB', description='RSS')
-        r.Processors(  self.getint('Processors'), metric="max")
+        r.Processors(  self.getint_roundup('Processors'), metric="max")
         r.SiteName(    self.get('Site'))
         r.ProbeName(   self.site_probe())
         r.Grid(        self.get('InfrastructureType')) # Best guess


### PR DESCRIPTION
- Handle printing the env from a `None` envfile argument, which is the default
- Update parsing of APEL records to handle cases where `:` is in the value (eg. `SubmitHost: http://localhost:8000`)
- Round up processor count to the nearest integer rather than down (so 7.9 becomes 8 instead of 7)