### PR TITLE
SOFTWARE-6027: Use OSG 24 for default builds

### DIFF
--- a/.github/workflows/build-k8s-container.yaml
+++ b/.github/workflows/build-k8s-container.yaml
@@ -32,7 +32,7 @@ jobs:
         DTAG: ${{ steps.mkdatetag.outputs.dtag }}
       run: |
         reponame="osg-htc/gratia-probe-k8s"
-        OSGVER=23
+        OSGVER=24
         tags=()
         for registry in hub.opensciencegrid.org; do
             tags+=("$registry/$reponame:$OSGVER-release")

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -26,7 +26,7 @@ jobs:
       run: echo "dtag=$(date +%Y%m%d-%H%M)" >> $GITHUB_OUTPUT
 
     - id: format-docker-repo
-      run: echo "repo-name=opensciencegrid/osg-pilot-container-probe" >> $GITHUB_OUTPUT
+      run: echo "repo-name=osg-htc/osg-pilot-container-probe" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2.7.0
@@ -50,5 +50,4 @@ jobs:
         context: .
         file: osg-pilot-container/Dockerfile
         push: true
-        tags: "docker.io/${{ steps.format-docker-repo.outputs.repo-name }}:${{ steps.mkdatetag.outputs.dtag }},\
-          hub.opensciencegrid.org/${{ steps.format-docker-repo.outputs.repo-name }}:${{ steps.mkdatetag.outputs.dtag }}"
+        tags: "hub.opensciencegrid.org/${{ steps.format-docker-repo.outputs.repo-name }}:${{ steps.mkdatetag.outputs.dtag }}"

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -1,13 +1,14 @@
 FROM almalinux:9
 
 ARG TIMESTAMP_IMAGE=gratia-probe-k8s:release-$(date +%Y%m%d-%H%M)
+ARG OSG_SERIES=24
 ENV GRATIA_PROBE_VERSION=$TIMESTAMP_IMAGE
 ARG UID=10000
 ARG GID=10000
 
 # Install EPEL, the OSG software base repo, and gratia-probe-common
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    yum install -y https://repo.opensciencegrid.org/osg/23-main/osg-23-main-el9-release-latest.rpm && \
+    yum install -y https://repo.opensciencegrid.org/osg/$OSG_SERIES-main/osg-$OSG_SERIES-main-el9-release-latest.rpm && \
     yum install -y gratia-probe-common python3-pip
 
 # Make probe runnable as non-root

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -8,7 +8,7 @@ ARG GID=10000
 
 # Install EPEL, the OSG software base repo, and gratia-probe-common
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    yum install -y https://repo.opensciencegrid.org/osg/$OSG_SERIES-main/osg-$OSG_SERIES-main-el9-release-latest.rpm && \
+    yum install -y https://repo.osg-htc.org/osg/$OSG_SERIES-main/osg-$OSG_SERIES-main-el9-release-latest.rpm && \
     yum install -y gratia-probe-common python3-pip
 
 # Make probe runnable as non-root

--- a/osg-pilot-container/Dockerfile
+++ b/osg-pilot-container/Dockerfile
@@ -2,8 +2,8 @@
 #   docker build -f osg-pilot-container/Dockerfile .
 
 # build rpms in a temporary container
-ARG BASE_OS=el8
-ARG BASE_OSG_SERIES=23
+ARG BASE_OS=el9
+ARG BASE_OSG_SERIES=24
 ARG BASE_YUM_REPO=release
 
 FROM opensciencegrid/software-base:$BASE_OSG_SERIES-$BASE_OS-$BASE_YUM_REPO as build-container
@@ -40,8 +40,8 @@ RUN osg-build rpmbuild /root/bld
 # build real container; copying in rpm results
 FROM opensciencegrid/software-base:$BASE_OSG_SERIES-$BASE_OS-$BASE_YUM_REPO
 
-ARG BASE_OS=el8
-ARG BASE_OSG_SERIES=23
+ARG BASE_OS=el9
+ARG BASE_OSG_SERIES=24
 ARG BASE_YUM_REPO=release
 
 


### PR DESCRIPTION
The GHAs for this repo don't appear to use a build matrix for el/release version.