### PR TITLE
Update collector query to check for defined Site or ResourceName

### DIFF
--- a/osg-pilot-container/osgpilot_meter
+++ b/osg-pilot-container/osgpilot_meter
@@ -265,7 +265,8 @@ schema_sql = [
 def query_current_attrs(opts, pool):
     coll = htcondor.Collector(pool)
 
-    filter_cond = 'SlotType != "Static"'
+    # Need at least one defined from Site and ResourceName for proper accounting
+    filter_cond = 'SlotType != "Static" && (GLIDEIN_ResourceName =!= UNDEFINED || GLIDEIN_Site =!= UNDEFINED) '
     if not opts.any_records:
         filter_cond += ' && IsOsgVoContainer =?= True'
 


### PR DESCRIPTION
The probe picked up ~30 records from a (misconfigured)? machine at ULAR with no SiteName between June 11th and 14th, which broke later processing. Removing these records allowed processing to resume. This PR adds an additional check to make sure that either site or resource is present in ingested records.