### PR TITLE
Handle undefined resource names

### DIFF
--- a/common/gratia/common/condor.py
+++ b/common/gratia/common/condor.py
@@ -565,7 +565,7 @@ def cream_match(match, desired):
 def get_classad_resource_name(classad):
     for attr in RESOURCE_NAME_ATTRS:
         resource_name = classad.get(attr)
-        if resource_name:
+        if resource_name and resource_name not in (classadLib.Value.Undefined, classadLib.Value.Error):
             return resource_name
     return None
 


### PR DESCRIPTION
If the resource name classad exists but is set to the value `classad.Value.Undefined` (we appear to have this when flocking to CHTC directly), allow processing to continue.  

Example of classads:

```
LastRemoteHost = "slot1_30@e2588.chtc.wisc.edu"
LastRemotePool = "cm.chtc.wisc.edu"
MATCH_EXP_JOBGLIDEIN_ResourceName = "Local Job"
MachineAttrGLIDEIN_ResourceName0 = undefined
```

Before this PR, it would look at `MachineAttrGLIDEIN_ResourceName0` first and return the undefined value, then break later in the code.  Now it says it's a local job, which seems better?

I leave it up to OSG to decide if they want CHTC to be counted.