### PR TITLE
SOFTWARE-6342: Fix handling of missing attributes in `get_classad_resource_name`

### DIFF
--- a/common/gratia/common/condor.py
+++ b/common/gratia/common/condor.py
@@ -564,7 +564,10 @@ def cream_match(match, desired):
 
 def get_classad_resource_name(classad):
     for attr in RESOURCE_NAME_ATTRS:
-        resource_name = classad.eval(attr)
+        try:
+            resource_name = classad.eval(attr)
+        except (KeyError, ValueError):
+            continue
         if resource_name and resource_name is not classadLib.Value.Undefined and resource_name is not classadLib.Value.Error:
             return resource_name
     return None

--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -2,7 +2,7 @@ Name:               gratia-probe
 Summary:            Gratia OSG accounting system probes
 Group:              Applications/System
 Version:            2.9.1
-Release:            2%{?dist}
+Release:            3%{?dist}
 License:            GPL
 URL:                https://github.com/opensciencegrid/gratia-probe
 Vendor:             The Open Science Grid <http://www.opensciencegrid.org/>
@@ -607,6 +607,9 @@ This is a transitional dummy package for gratia-probe-slurm; it may safely be re
 %files slurm
 
 %changelog
+* Fri May 1 2026 Matt Westphall <westphall@wisc.edu.> -  2.9.1-3
+- Add missing try/catch block (SOFTWARE-6342)
+
 * Thu Feb 5 2026 Matt Westphall <westphall@wisc.edu.> -  2.9.1-2
 - Add check for empty classad resource names
 


### PR DESCRIPTION
We have observed that the change from `classad.get` to `classad.eval` in https://github.com/opensciencegrid/gratia-probe/pull/196 breaks gratia probe on hosted CEs, but not on the OSPool APs. Copilot suggests this might be because `classad.eval` throws a KeyError on missing attribute names.