### PR TITLE
SOFTWARE-6351: Compress old logs

### DIFF
--- a/common/gratia/common/condor.py
+++ b/common/gratia/common/condor.py
@@ -21,7 +21,7 @@ import subprocess
 from typing import List, Tuple
 
 from gratia.common.Gratia import DebugPrint
-from gratia.common.debug import DebugPrintTraceback
+from gratia.common.debug import DebugPrintTraceback, CompressOldLogs
 from gratia.common import GratiaCore
 from gratia.common import GratiaWrapper
 from gratia.common import Gratia
@@ -271,6 +271,9 @@ def main(probe_name):
     GratiaCore.Initialize(opts.gratia_config)
     global g_probe_config
     g_probe_config = opts.gratia_config
+
+    # Compress any log files left over from previous days.
+    CompressOldLogs()
 
     # setup htcondor environment 
     setup_environment()

--- a/common/gratia/common/debug.py
+++ b/common/gratia/common/debug.py
@@ -4,6 +4,9 @@ from __future__ import print_function
 import os
 import sys
 import time
+import glob
+import gzip
+import shutil
 import syslog
 import traceback
 
@@ -82,6 +85,30 @@ def LogFileName():
     if not filename:
         filename = time.strftime('%Y-%m-%d') + '.log'
     return os.path.join(getGratiaConfig().get_LogFolder(), filename)
+
+
+def CompressOldLogs():
+    '''Gzip-compress every log file in the log folder except the one currently in use for today's logging.'''
+
+    try:
+        log_dir = getGratiaConfig().get_LogFolder()
+        if not log_dir or not os.path.isdir(log_dir):
+            return
+
+        current_file = os.path.abspath(LogFileName())
+
+        for filepath in glob.glob(os.path.join(log_dir, '*.log')):
+            filepath = os.path.abspath(filepath)
+            if filepath == current_file:
+                continue
+            try:
+                with open(filepath, 'rb') as f_in, gzip.open(filepath + '.gz', 'wb') as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+                os.remove(filepath)
+            except OSError as exc:
+                print('Gratia: Unable to compress old log file: ', filepath, ' ', exc, file=sys.stderr)
+    except Exception:
+        print('Gratia: Unable to compress old log files: ', sys.exc_info(), file=sys.stderr)
 
 
 def LogToFile(message):

--- a/rpm/gratia-probe.spec
+++ b/rpm/gratia-probe.spec
@@ -1,7 +1,7 @@
 Name:               gratia-probe
 Summary:            Gratia OSG accounting system probes
 Group:              Applications/System
-Version:            2.9.2
+Version:            2.9.3
 Release:            1%{?dist}
 License:            GPL
 URL:                https://github.com/opensciencegrid/gratia-probe
@@ -607,6 +607,9 @@ This is a transitional dummy package for gratia-probe-slurm; it may safely be re
 %files slurm
 
 %changelog
+* Wed Jul 08 2026 Matt Westphall <westphall@wisc.edu> -  2.9.3-1
+- Compress back-dated log files on probe startup (SOFTWARE-6351)
+
 * Tue May 12 2026 Matt Westphall <westphall@wisc.edu> -  2.9.2-1
 - Fix issue in 2.9.1-2 that prevented delivery of records (SOFTWARE-6342)
 


### PR DESCRIPTION
Compress all non-current logs on probe startup. Tested as a scratch build on canary2-ce:

```
[root@osg-hosted-ce-chtc-canary2-ce-7685dc9958-48n54 /]# rpm -qa | grep gratia
osg-configure-gratia-4.3.2-1.osg25.el9.noarch
gratia-probe-common-2.9.3-1.osg25.el9.noarch
gratia-probe-htcondor-ce-2.9.3-1.osg25.el9.noarch
[root@osg-hosted-ce-chtc-canary2-ce-7685dc9958-48n54 /]# ls -lah /var/log/condor-ce/gratia/
total 176K
-rw-r--r-- 1 condor condor 1.6K Jul  8 16:49 2026-07-07.log.gz
-rw-r--r-- 1 condor condor 158K Jul  8 17:34 2026-07-08.log
```